### PR TITLE
refactor: Change argument types for query functions

### DIFF
--- a/examples/basic_crud.rs
+++ b/examples/basic_crud.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
 
     // READ
     println!("2. Reading user by ID...");
-    let found_user = User::by_id(&pool, user.id).await?;
+    let found_user = User::by_id(&pool, &user.id).await?;
     println!(
         "   Found user: {} ({})\n",
         found_user.name, found_user.email
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
     println!("2bis. Reading user by ID and email...");
     let id = found_user.id;
     let search = User::select()
-        .where_id(Where::Eq, id)
+        .where_id(Where::Eq, &id)
         .where_email(Where::Eq, "alice@example.com")
         .build(&pool)
         .await?;
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
 
     // Verify deletion
     println!("5. Verifying deletion...");
-    match User::by_id(&pool, user_id).await {
+    match User::by_id(&pool, &user_id).await {
         Ok(_) => println!("   ERROR: User still exists!"),
         Err(_) => println!("   Confirmed: User no longer exists"),
     }

--- a/examples/basic_crud.rs
+++ b/examples/basic_crud.rs
@@ -28,6 +28,7 @@ struct User {
     #[lorm(new = "chrono::Utc::now().fixed_offset()")]
     pub created_at: chrono::DateTime<FixedOffset>,
 
+    #[allow(unused)]
     #[lorm(updated_at)]
     #[lorm(new = "chrono::Utc::now().fixed_offset()")]
     pub updated_at: chrono::DateTime<FixedOffset>,

--- a/examples/query_builder.rs
+++ b/examples/query_builder.rs
@@ -32,6 +32,7 @@ struct Product {
     #[lorm(new = "chrono::Utc::now().fixed_offset()")]
     pub created_at: chrono::DateTime<FixedOffset>,
 
+    #[allow(unused)]
     #[lorm(updated_at)]
     #[lorm(new = "chrono::Utc::now().fixed_offset()")]
     pub updated_at: chrono::DateTime<FixedOffset>,

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -46,8 +46,8 @@ async fn main() -> Result<()> {
     println!("   Created user: {} {}\n", user.id, user.email);
 
     let s = User::select()
-        .where_id(Where::Eq, id)
-        .where_email(Where::Eq, user.email)
+        .where_id(Where::Eq, &id)
+        .where_email(Where::Eq, &user.email)
         .order_by_email()
         .asc()
         .build(&pool)

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -43,8 +43,8 @@ async fn transfer(pool: &SqlitePool, from_id: &Uuid, to_id: &Uuid, amount: i64) 
     let mut tx = pool.begin().await?;
 
     // Get accounts within transaction
-    let mut from_account = Account::by_id(&mut *tx, from_id.clone()).await?;
-    let mut to_account = Account::by_id(&mut *tx, to_id.clone()).await?;
+    let mut from_account = Account::by_id(&mut *tx, from_id).await?;
+    let mut to_account = Account::by_id(&mut *tx, to_id).await?;
 
     // Check balance
     if from_account.balance < amount {
@@ -105,8 +105,8 @@ async fn main() -> Result<()> {
     transfer(&pool, &alice.id, &bob.id, 200).await?;
 
     // Verify balances
-    let alice_updated = Account::by_id(&pool, alice.id).await?;
-    let bob_updated = Account::by_id(&pool, bob.id).await?;
+    let alice_updated = Account::by_id(&pool, &alice.id).await?;
+    let bob_updated = Account::by_id(&pool, &bob.id).await?;
     println!("   Alice's balance: ${}", alice_updated.balance);
     println!("   Bob's balance: ${}\n", bob_updated.balance);
 
@@ -118,8 +118,8 @@ async fn main() -> Result<()> {
     }
 
     // Verify balances unchanged
-    let alice_final = Account::by_id(&pool, alice.id).await?;
-    let bob_final = Account::by_id(&pool, bob.id).await?;
+    let alice_final = Account::by_id(&pool, &alice.id).await?;
+    let bob_final = Account::by_id(&pool, &bob.id).await?;
     println!("   Alice's balance (unchanged): ${}", alice_final.balance);
     println!("   Bob's balance (unchanged): ${}\n", bob_final.balance);
 

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -28,6 +28,7 @@ struct Account {
     #[lorm(new = "chrono::Utc::now().fixed_offset()")]
     pub created_at: chrono::DateTime<FixedOffset>,
 
+    #[allow(unused)]
     #[lorm(updated_at)]
     #[lorm(new = "chrono::Utc::now().fixed_offset()")]
     pub updated_at: chrono::DateTime<FixedOffset>,

--- a/lorm-macros/src/attributes.rs
+++ b/lorm-macros/src/attributes.rs
@@ -139,7 +139,7 @@ impl ColumnProperties {
     pub fn is_set(&self, base: TokenStream, ty: &Type) -> TokenStream {
         match &self.is_set_expression {
             Some(expr) => quote! {#base.#expr},
-            None => quote! {#base == #ty::default()},
+            None => quote! {*#base == #ty::default()},
         }
     }
 }

--- a/lorm-macros/src/orm/by.rs
+++ b/lorm-macros/src/orm/by.rs
@@ -1,5 +1,5 @@
 use crate::models::OrmModel;
-use crate::utils::{db_placeholder, get_bind_type_constraint};
+use crate::utils::{db_placeholder, get_bind_param_type_and_usage, get_bind_type_where_constraint};
 use quote::{__private::TokenStream, format_ident, quote};
 
 pub fn generate_by(
@@ -15,20 +15,29 @@ pub fn generate_by(
     let stream: Vec<(TokenStream, TokenStream)> = model.query_columns().map(|column| {
         let field_name = &column.field;
         let column_name = &column.column_name;
-        let field_type_constraints = get_bind_type_constraint(column.base_field, database_type).unwrap();
+
+        let lifetime = quote! {'a};
+        let parameter = quote! {value};
+        let field_type_constraints = get_bind_type_where_constraint(&column.ty, database_type, &lifetime).unwrap();
+        let (param_type, param_value) = get_bind_param_type_and_usage(&parameter, &column.ty, &lifetime).unwrap();
         let by_fn = format_ident!("by_{}", field_name);
 
         let columns = model.full_column_select();
         let placeholder = db_placeholder(column.base_field, 1).unwrap();
         let sql_ident = format!("SELECT {columns} FROM {table_name} WHERE {column_name} = {placeholder}");
+
+        let signature = quote! {
+            async fn #by_fn<#lifetime>(executor: E, #parameter: #param_type) -> lorm::errors::Result<#struct_name> where #field_type_constraints
+        };
+
         let trait_code = quote! {
-            async fn #by_fn<T: #field_type_constraints>(executor: E, value: T) -> lorm::errors::Result<#struct_name>;
+            #signature;
         };
 
         let impl_code = quote! {
-            async fn #by_fn<T: #field_type_constraints>(executor: E, value: T) -> lorm::errors::Result<#struct_name> {
+            #signature {
                 let r = sqlx::query_as::<_, #struct_name>(#sql_ident)
-                    .bind(value)
+                    .bind(#param_value)
                     .fetch_one(executor).await?;
                 Ok(r)
             }

--- a/lorm-macros/src/orm/column.rs
+++ b/lorm-macros/src/orm/column.rs
@@ -1,5 +1,7 @@
 use crate::attributes::ColumnProperties;
-use quote::ToTokens;
+use crate::utils::is_option_wrapped;
+use quote::__private::TokenStream;
+use quote::{ToTokens, quote};
 use syn::Field;
 use syn::Ident;
 use syn::Type;
@@ -15,6 +17,21 @@ pub(crate) struct Column<'a> {
 }
 
 impl<'a> Column<'a> {
+    /// Generate the token stream to access the field on `self`.
+    pub(crate) fn self_accessor(&self) -> TokenStream {
+        let base_ident = self.base_field.ident.as_ref().unwrap();
+        if self.is_flattened {
+            let field_ident = &self.field;
+            if is_option_wrapped(&self.base_field.ty) {
+                quote! {self.#base_ident.as_ref().map(|base| &base.#field_ident)}
+            } else {
+                quote! {&self.#base_ident.#field_ident}
+            }
+        } else {
+            quote! {&self.#base_ident}
+        }
+    }
+
     /// Whether a `by_*`, `with_*` or selector function should be generated for this column.
     ///
     /// Such a selector should be generated if any of the

--- a/lorm-macros/src/orm/delete.rs
+++ b/lorm-macros/src/orm/delete.rs
@@ -10,11 +10,11 @@ pub fn generate_delete(executor_type: &TokenStream, model: &OrmModel) -> syn::Re
 
     // Primary key
     let primary_key = model.primary_key();
-    let pk_field = &primary_key.field;
+    let pk_value = primary_key.self_accessor();
     let pk_column = &primary_key.column_name;
     let pk_placeholder = format!(
         "{pk_column} = {}",
-        db_placeholder(primary_key.base_field, 1).unwrap()
+        db_placeholder(primary_key.base_field, 1)?
     );
     let sql_ident = format!("DELETE FROM {table_name} WHERE {pk_placeholder}");
 
@@ -26,7 +26,7 @@ pub fn generate_delete(executor_type: &TokenStream, model: &OrmModel) -> syn::Re
         impl<'e, E: #executor_type> #trait_ident<'e, E> for #struct_name {
             async fn delete(&self, executor: E) -> lorm::errors::Result<()> {
                 sqlx::query(#sql_ident)
-                .bind(&self.#pk_field)
+                .bind(#pk_value)
                 .execute(executor).await?;
                 Ok(())
             }

--- a/lorm-macros/src/orm/save.rs
+++ b/lorm-macros/src/orm/save.rs
@@ -11,14 +11,78 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
 
     let full_select_columns = model.full_column_select();
 
+    // Primary key
     let primary_key = model.primary_key();
+    let primary_key_var = quote! {primary_key};
+    let pk_column = &primary_key.column_name;
+    let pk_value = primary_key.self_accessor();
+    let pk_placeholder = format!(
+        "{} = {}",
+        pk_column,
+        db_placeholder(primary_key.base_field, model.update_columns().count() + 1)?
+    );
+    let pk_is_set = &primary_key
+        .column_properties
+        .is_set(quote! { #pk_value }, &primary_key.ty);
+    let pk_code = if primary_key.column_properties.readonly {
+        quote! {}
+    } else {
+        let pk_new_method = &primary_key.column_properties.new_expression;
+        quote! {
+            let #primary_key_var = #pk_new_method;
+        }
+    };
+
+    // Created at
+    let created_at_var = quote! {created_at};
+    let created_at_code = match model.created_at() {
+        None => quote! {},
+        Some(column) => {
+            if column.column_properties.readonly {
+                quote! {}
+            } else {
+                let new_method = &column.column_properties.new_expression;
+                quote! {
+                    let #created_at_var = #new_method;
+                }
+            }
+        }
+    };
+
+    // Updated at
+    let updated_at_var = quote! {updated_at};
+    let updated_at_code = match model.updated_at() {
+        None => quote! {},
+        Some(column) => {
+            if column.column_properties.readonly {
+                quote! {}
+            } else {
+                let new_method = &column.column_properties.new_expression;
+                quote! {
+                    let #updated_at_var = #new_method;
+                }
+            }
+        }
+    };
+
+    let column_value = |column: &Column, use_created_at_var: bool| {
+        if column.column_properties.created_at && use_created_at_var {
+            created_at_var.clone()
+        } else if column.column_properties.updated_at {
+            updated_at_var.clone()
+        } else if column.column_properties.primary_key {
+            primary_key_var.clone()
+        } else {
+            column.self_accessor()
+        }
+    };
 
     // prepare `insertable` fields
     let insert_value_placeholders =
         create_insert_placeholders(&model.insert_columns().collect::<Vec<_>>());
     let insert_values = model
         .insert_columns()
-        .map(|col| col.field.clone())
+        .map(|col| column_value(col, true))
         .collect::<Vec<_>>();
     let insert_columns = model
         .insert_columns()
@@ -31,58 +95,8 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
         create_update_placeholders(&model.update_columns().collect::<Vec<_>>());
     let update_values = model
         .update_columns()
-        .map(|col| col.field.clone())
+        .map(|col| column_value(col, false))
         .collect::<Vec<_>>();
-
-    // Primary key
-    let pk_column = &primary_key.column_name;
-    let pk_field = &primary_key.field;
-    let pk_placeholder = format!(
-        "{} = {}",
-        pk_column,
-        db_placeholder(primary_key.base_field, model.update_columns().count() + 1)?
-    );
-    let pk_is_set = &primary_key
-        .column_properties
-        .is_set(quote! { to_save.#pk_field }, &primary_key.ty);
-    let pk_code = if primary_key.column_properties.readonly {
-        quote! {}
-    } else {
-        let pk_new_method = &primary_key.column_properties.new_expression;
-        quote! {
-            to_save.#pk_field = #pk_new_method;
-        }
-    };
-
-    let created_at_code = match model.created_at() {
-        None => quote! {},
-        Some(column) => {
-            if column.column_properties.readonly {
-                quote! {}
-            } else {
-                let new_method = &column.column_properties.new_expression;
-                let field = &column.field;
-                quote! {
-                    to_save.#field = #new_method;
-                }
-            }
-        }
-    };
-
-    let updated_at_code = match model.updated_at() {
-        None => quote! {},
-        Some(column) => {
-            if column.column_properties.readonly {
-                quote! {}
-            } else {
-                let new_method = &column.column_properties.new_expression;
-                let field = &column.field;
-                quote! {
-                    to_save.#field = #new_method;
-                }
-            }
-        }
-    };
 
     let insert_sql_ident = format!(
         "INSERT INTO {table_name} ({insert_columns}) VALUES ({insert_value_placeholders}) RETURNING {full_select_columns}"
@@ -100,7 +114,6 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
         {
             async fn save(&self, executor: E) -> lorm::errors::Result<#struct_name>
             {
-                let mut to_save = self.clone();
                 #updated_at_code
                 match #pk_is_set {
                     true => {
@@ -108,7 +121,7 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
                         #created_at_code
                         let r = sqlx::query_as::<_, #struct_name>(#insert_sql_ident)
                         #(
-                            .bind(&to_save.#insert_values)
+                            .bind(#insert_values)
                         )*
                         .fetch_one(executor).await?;
                         Ok(r)
@@ -116,9 +129,9 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
                     false => {
                         let r = sqlx::query_as::<_, #struct_name>(#update_sql_ident)
                         #(
-                            .bind(&self.#update_values)
+                            .bind(#update_values)
                         )*
-                        .bind(&self.#pk_field)
+                        .bind(#pk_value)
                         .fetch_one(executor).await?;
                         Ok(r)
                     }

--- a/lorm-macros/src/orm/select.rs
+++ b/lorm-macros/src/orm/select.rs
@@ -1,5 +1,5 @@
 use crate::models::OrmModel;
-use crate::utils::get_bind_type_constraint;
+use crate::utils::{get_bind_param_type_and_usage, get_bind_type_where_constraint};
 use quote::{__private::TokenStream, format_ident, quote};
 
 pub fn generate_select(
@@ -12,18 +12,27 @@ pub fn generate_select(
     let struct_name = model.struct_name;
     let struct_visibility = model.struct_visibility;
 
-    let impl_tokens: Vec<TokenStream> = model.query_columns().map(|column| {
+    let lifetime = quote! {'a};
+
+    let impl_tokens: Vec<TokenStream> = model.query_columns().map(|column| (|| -> syn::Result<_> {
         let field_name = &column.field;
         let column_name = &column.column_name;
-        let field_type_constraints = get_bind_type_constraint(column.base_field, database_type).unwrap();
+
+        let constraints = get_bind_type_where_constraint(&column.ty, database_type, &lifetime)?;
+        let parameter = quote! {value};
+        let (param_type, param_use) = get_bind_param_type_and_usage(&parameter, &column.ty, &lifetime)?;
+        let param = quote! {#parameter: #param_type};
+
         let where_between_fn = format_ident!("where_between_{}", field_name);
         let where_fn = format_ident!("where_{}", field_name);
         let having_fn = format_ident!("having_{}", field_name);
         let order_by_fn = format_ident!("order_by_{}", field_name);
         let group_by_fn = format_ident!("group_by_{}", field_name);
 
+        let (left_type, left_use) = get_bind_param_type_and_usage(&quote! {left}, &column.ty, &lifetime)?;
+        let (right_type, right_use) = get_bind_param_type_and_usage(&quote! {right}, &column.ty, &lifetime)?;
         let code = quote! {
-            #struct_visibility fn #having_fn<T: #field_type_constraints>(mut self, op: lorm::predicates::Having, fun: lorm::predicates::Function, value: T) -> #builder_struct_ident {
+            #struct_visibility fn #having_fn(mut self, op: lorm::predicates::Having, fun: lorm::predicates::Function, #param) -> Self where #constraints {
                 if self.is_having == false {
                     self.builder.push(" HAVING");
                     self.is_having = true;
@@ -36,11 +45,11 @@ pub fn generate_select(
                     _ => format!(" {}({}) {} ", fun, #column_name, op).to_string()
                 };
                 self.builder.push(stmt);
-                self.builder.push_bind(value);
+                self.builder.push_bind(#param_use);
                 self
             }
 
-            #struct_visibility fn #where_fn<T: #field_type_constraints>(mut self, op: lorm::predicates::Where, value: T) -> #builder_struct_ident {
+            #struct_visibility fn #where_fn(mut self, op: lorm::predicates::Where, #param) -> Self where #constraints {
                 if self.is_where == false {
                     self.builder.push(" WHERE");
                     self.is_where = true;
@@ -49,11 +58,11 @@ pub fn generate_select(
                 }
                 let stmt = format!(" {} {} ", #column_name, op).to_string();
                     self.builder.push(stmt);
-                    self.builder.push_bind(value);
+                    self.builder.push_bind(#param_use);
                 self
             }
 
-            #struct_visibility fn #where_between_fn<T: #field_type_constraints>(mut self, left: T, right: T) -> #builder_struct_ident {
+            #struct_visibility fn #where_between_fn(mut self, left: #left_type, right: #right_type) -> Self where #constraints {
                 if self.is_where == false {
                     self.builder.push(" WHERE");
                     self.is_where = true;
@@ -62,13 +71,13 @@ pub fn generate_select(
                 }
                 let stmt = format!(" {} BETWEEN ", #column_name).to_string();
                 self.builder.push(stmt);
-                self.builder.push_bind(left);
+                self.builder.push_bind(#left_use);
                 self.builder.push(" AND ");
-                self.builder.push_bind(right);
+                self.builder.push_bind(#right_use);
                 self
             }
 
-            #struct_visibility fn #order_by_fn(mut self) -> #builder_struct_ident {
+            #struct_visibility fn #order_by_fn(mut self) -> Self {
                 if self.is_order_by == false {
                     self.builder.push(" ORDER BY");
                     self.is_order_by = true;
@@ -80,7 +89,7 @@ pub fn generate_select(
                 self
             }
 
-            #struct_visibility fn #group_by_fn(mut self) -> #builder_struct_ident {
+            #struct_visibility fn #group_by_fn(mut self) -> Self {
                 if self.is_group_by == false {
                     self.builder.push(" GROUP BY");
                     self.is_group_by = true;
@@ -92,36 +101,36 @@ pub fn generate_select(
                 self
             }
         };
-        code
-    }).collect::<Vec<_>>();
+        Ok(code)
+    })()).collect::<Result<Vec<_>, _>>()?;
 
     let select_columns = model.full_column_select();
     let table_name = &model.table_name;
     let select_base = format!("SELECT {select_columns} from {table_name}");
 
     Ok(quote! {
-        #struct_visibility trait #trait_ident {
-            fn select() -> #builder_struct_ident;
+        #struct_visibility trait #trait_ident<#lifetime> {
+            fn select() -> #builder_struct_ident<#lifetime>;
         }
 
-        impl #trait_ident for #struct_name {
-            fn select() -> #builder_struct_ident {
+        impl<#lifetime> #trait_ident<#lifetime> for #struct_name {
+            fn select() -> #builder_struct_ident<#lifetime> {
                 let builder = sqlx::QueryBuilder::new(#select_base);
                 #builder_struct_ident { builder, is_where: false, is_having: false, is_group_by: false, is_order_by: false }
             }
         }
 
         #[derive(Default)]
-        #struct_visibility struct #builder_struct_ident {
-            builder: sqlx::QueryBuilder<'static, #database_type>,
+        #struct_visibility struct #builder_struct_ident<#lifetime> {
+            builder: sqlx::QueryBuilder<#lifetime, #database_type>,
             is_where: bool,
             is_having: bool,
             is_group_by: bool,
             is_order_by: bool
         }
 
-        impl #builder_struct_ident {
-            #struct_visibility fn having_all_count(mut self, op: lorm::predicates::Having, value: i64) -> #builder_struct_ident {
+        impl<#lifetime> #builder_struct_ident<#lifetime> {
+            #struct_visibility fn having_all_count(mut self, op: lorm::predicates::Having, value: i64) -> Self {
                 if self.is_having == false {
                     self.builder.push(" HAVING");
                     self.is_having = true;
@@ -134,23 +143,23 @@ pub fn generate_select(
                 self
             }
 
-            #struct_visibility fn asc(mut self) -> #builder_struct_ident {
+            #struct_visibility fn asc(mut self) -> Self {
                 self.builder.push(" ASC ");
                 self
             }
 
-            #struct_visibility fn desc(mut self) -> #builder_struct_ident {
+            #struct_visibility fn desc(mut self) -> Self {
                 self.builder.push(" DESC ");
                 self
             }
 
-            #struct_visibility fn limit(mut self, limit: i64) -> #builder_struct_ident {
+            #struct_visibility fn limit(mut self, limit: i64) -> Self {
                 self.builder.push(" LIMIT ");
                 self.builder.push_bind(limit);
                 self
             }
 
-            #struct_visibility fn offset(mut self, offset: i64) -> #builder_struct_ident {
+            #struct_visibility fn offset(mut self, offset: i64) -> Self {
                 self.builder.push(" OFFSET ");
                 self.builder.push_bind(offset);
                 self

--- a/lorm-macros/src/orm/with.rs
+++ b/lorm-macros/src/orm/with.rs
@@ -1,5 +1,5 @@
 use crate::models::OrmModel;
-use crate::utils::{db_placeholder, get_bind_type_constraint};
+use crate::utils::{db_placeholder, get_bind_param_type_and_usage, get_bind_type_where_constraint};
 use quote::{__private::TokenStream, format_ident, quote};
 
 pub fn generate_with(
@@ -13,27 +13,37 @@ pub fn generate_with(
     let table_name = &model.table_name;
     let table_columns = model.full_column_select();
 
-    let stream: Vec<(TokenStream, TokenStream)> = model.query_columns().map(|column| {
+    let stream: Vec<(TokenStream, TokenStream)> = model.query_columns().map(|column| (|| -> syn::Result<_> {
         let field_name = &column.field;
         let column_name = &column.column_name;
-        let field_type_constraints = get_bind_type_constraint(column.base_field, database_type).unwrap();
+
+        let lifetime = quote! {'a};
+
+        let constraints = get_bind_type_where_constraint(&column.ty, database_type, &lifetime).unwrap();
+        let param = quote! {value};
+        let (param_type, param_value) = get_bind_param_type_and_usage(&param, &column.ty, &lifetime)?;
+
         let with_fn = format_ident!("with_{}",field_name);
         let placeholder = db_placeholder(column.base_field, 1).unwrap();
+
+        let signature = quote! {
+            async fn #with_fn<#lifetime>(executor: E, #param: #param_type) -> lorm::errors::Result<Vec<#struct_name>> where #constraints
+        };
         let trait_code = quote! {
-            async fn #with_fn<T: #field_type_constraints>(executor: E, value: T) -> lorm::errors::Result<Vec<#struct_name>>;
+            #signature;
         };
         let sql_ident = format!("SELECT {table_columns} FROM {table_name} WHERE {column_name} = {placeholder}");
 
         let impl_code = quote! {
-            async fn #with_fn<T: #field_type_constraints>(executor: E, value: T) -> lorm::errors::Result<Vec<#struct_name>> {
+            #signature {
                 let r = sqlx::query_as::<_, Self>(#sql_ident)
-                    .bind(value)
+                    .bind(#param_value)
                     .fetch_all(executor).await?;
                 Ok(r)
             }
         };
-        (trait_code, impl_code)
-    }).collect::<Vec<(_, _)>>();
+        Ok((trait_code, impl_code))
+    })()).collect::<Result<Vec<(_, _)>, _>>()?;
     let (trait_tokens, impl_tokens): (Vec<TokenStream>, Vec<TokenStream>) =
         stream.into_iter().unzip();
 

--- a/lorm-macros/src/utils.rs
+++ b/lorm-macros/src/utils.rs
@@ -35,11 +35,39 @@ pub(crate) fn is_primitive_type(ty: &Type) -> bool {
     }
 }
 
-/// Returns the type without reference, unwrapping it from an `Option<>` if present.
-///
-/// For example, `Option<&String>` becomes `String`, and `&i32` becomes `i32`.
-pub(crate) fn get_type_without_reference(ty: &Type) -> syn::Result<Type> {
+/// Check whether the provided type is an [Option]
+pub(crate) fn is_option_wrapped(ty: &Type) -> bool {
     match ty {
+        Type::Path(type_path) => {
+            let last_segment = type_path
+                .path
+                .segments
+                .last()
+                .expect("Type path should have at least one segment");
+            let ident = &last_segment.ident;
+
+            // Check for Option types and recurse
+            if ident == "Option"
+                && let PathArguments::AngleBracketed(angle_bracketed) = &last_segment.arguments
+                && let Some(syn::GenericArgument::Type(_inner_type)) = angle_bracketed.args.first()
+            {
+                true
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Convert the type into the type that the db columns have. This does two things:
+///
+/// - Returns the type without its `Option<>` wrapper if present.
+/// - Converts `String` to `&str`.
+///
+/// For example, `Option<String>` becomes `String`, and `Option<i32>` becomes `i32`.
+pub(crate) fn to_column_type(ty: &Type) -> syn::Result<Type> {
+    let res = match ty {
         Type::Path(type_path) => {
             let last_segment = type_path
                 .path
@@ -53,14 +81,23 @@ pub(crate) fn get_type_without_reference(ty: &Type) -> syn::Result<Type> {
                 && let PathArguments::AngleBracketed(angle_bracketed) = &last_segment.arguments
                 && let Some(syn::GenericArgument::Type(inner_type)) = angle_bracketed.args.first()
             {
-                return get_type_without_reference(inner_type);
+                inner_type
+            } else {
+                ty
             }
-
-            // Always return the type without reference
-            parse(ty.into_token_stream().into())
         }
-        _ => parse(ty.into_token_stream().into()),
+        _ => ty,
+    };
+
+    if let Type::Path(type_path) = res
+        && let Some(last_segment) = type_path.path.segments.last()
+        && last_segment.ident == "String"
+    {
+        return parse(quote::quote! { str }.into());
     }
+
+    // This is a clone in disguise as `Type` doesn't implement `Clone`
+    parse(res.into_token_stream().into())
 }
 
 /// Generates a database-specific placeholder for a single field.
@@ -115,39 +152,48 @@ pub(crate) fn database_type(input: &DeriveInput) -> syn::Result<TokenStream> {
     }
 }
 
-/// Checks whether a type is `String` or `str`.
-fn is_string_type(ty: &Type) -> bool {
-    if let Type::Path(type_path) = ty {
-        if let Some(segment) = type_path.path.segments.last() {
-            let type_name = segment.ident.to_string();
-            matches!(type_name.as_str(), "String" | "str")
-        } else {
-            false
-        }
+/// Generates the type constraints for the `where` clause needed for binding a field value to SQLx queries.
+///
+/// These constraints are that the field type implements `sqlx::Encode` and `sqlx::Type` for the specific database type.
+/// Field types that are wrapped with an [Option] are stripped of it.
+pub(crate) fn get_bind_type_where_constraint(
+    ty: &Type,
+    database_type: &TokenStream,
+    encode_lifetime: &TokenStream,
+) -> syn::Result<TokenStream> {
+    let base_type = to_column_type(ty)?;
+    let constraints = vec![
+        quote! {sqlx::Encode<#encode_lifetime, #database_type>},
+        quote! {sqlx::Type<#database_type>},
+    ];
+    let col_type = if is_primitive_type(&base_type) {
+        base_type
     } else {
-        false
-    }
+        parse(quote::quote! { &#encode_lifetime #base_type }.into())?
+    };
+    let x = quote! {#col_type: #(#constraints)+*};
+    Ok(x)
 }
 
-/// Generates the type constraints needed for binding a field value to SQLx queries.
+/// Generates the type for the bind parameter and its usage.
 ///
-/// Returns different trait bounds depending on whether the field is a primitive type or complex type.
-/// For primitives, uses `Encode` and `Type` traits. For complex types, also includes `Into` or `AsRef`.
-pub(crate) fn get_bind_type_constraint(
-    field: &Field,
-    database_type: &TokenStream,
-) -> syn::Result<TokenStream> {
-    let field_type = get_type_without_reference(&field.ty)?;
-    if is_primitive_type(&field.ty) {
-        Ok(quote! { 'static + sqlx::Encode<'static, #database_type> + sqlx::Type<#database_type> })
-    } else {
-        let as_ref = if is_string_type(&field_type) || is_primitive_type(&field_type) {
-            quote! { std::convert::Into<#field_type> }
-        } else {
-            quote! { std::convert::AsRef<#field_type> }
-        };
-        Ok(
-            quote! { 'static + sqlx::Encode<'static, #database_type> + sqlx::Type<#database_type> + #as_ref },
+/// For primitive types and stringy types (String and str), the parameter is of type `impl Into<...>`, for all other types it uses `impl Borrow<...>`.
+pub(crate) fn get_bind_param_type_and_usage(
+    param: &TokenStream,
+    ty: &Type,
+    encode_lifetime: &TokenStream,
+) -> syn::Result<(TokenStream, TokenStream)> {
+    let base_type = to_column_type(ty)?;
+    let res = if is_primitive_type(&base_type) {
+        (
+            quote! {impl std::convert::Into<#base_type>},
+            quote! {#param.into()},
         )
-    }
+    } else {
+        (
+            quote! {&#encode_lifetime (impl std::borrow::Borrow<#base_type> + ?Sized)},
+            quote! {#param.borrow()},
+        )
+    };
+    Ok(res)
 }

--- a/lorm/tests/main.rs
+++ b/lorm/tests/main.rs
@@ -94,11 +94,11 @@ async fn test_user_does_not_exists() {
     let pool = get_pool().await.expect("Failed to create pool");
 
     let email = SafeEmail().fake::<String>();
-    let res = User::by_email(&pool, email).await;
+    let res = User::by_email(&pool, &email).await;
     assert_eq!(res.is_err(), true);
 
     let id = Uuid::new_v4();
-    let res = User::by_id(&pool, id).await;
+    let res = User::by_id(&pool, &id).await;
     assert_eq!(res.is_err(), true);
 }
 
@@ -111,13 +111,13 @@ async fn test_user_is_created() {
     u.email = email.clone();
     let u = u.save(&pool).await.unwrap();
 
-    let res = User::by_id(&pool, u.id).await;
+    let res = User::by_id(&pool, &u.id).await;
     assert_eq!(res.is_err(), false);
 
     let u = res.unwrap();
     assert_eq!(u.created_at.to_rfc2822() == u.updated_at.to_rfc2822(), true);
 
-    let res = User::by_email(&pool, email).await;
+    let res = User::by_email(&pool, &email).await;
     assert_eq!(res.is_err(), false);
 }
 
@@ -135,7 +135,7 @@ async fn test_user_is_updated() {
     let email = SafeEmail().fake::<String>();
     u.email = email.clone();
     let u = u.save(&pool).await.unwrap();
-    let res = User::by_id(&pool, u.id).await;
+    let res = User::by_id(&pool, &u.id).await;
     assert_eq!(res.is_err(), false);
     let u = res.unwrap();
     assert_eq!(u.email, email);
@@ -150,11 +150,11 @@ async fn test_user_is_deleted() {
     u.email = SafeEmail().fake::<String>();
     let u = u.save(&pool).await.unwrap();
 
-    let res = User::by_id(&pool, u.id).await;
+    let res = User::by_id(&pool, &u.id).await;
     assert_eq!(res.is_err(), false);
 
     u.delete(&pool).await.unwrap();
-    let res = User::by_id(&pool, u.id).await;
+    let res = User::by_id(&pool, &u.id).await;
     assert_eq!(res.is_err(), true);
 }
 

--- a/lorm/tests/main.rs
+++ b/lorm/tests/main.rs
@@ -59,6 +59,7 @@ struct AltUser {
     #[lorm(readonly)]
     pub created_at: chrono::DateTime<FixedOffset>,
 
+    #[allow(unused)]
     #[lorm(updated_at)]
     #[lorm(new = "chrono::Utc::now().fixed_offset()")]
     pub updated_at: chrono::DateTime<FixedOffset>,


### PR DESCRIPTION
See 4. in #2. It also removes the need for `.clone()` in `save`.

Breaking because arguments need to be passed in by reference