### PR TITLE
feat(macros)!: migrate is_set attribute to darling Callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Add `#[automatically_derived]` to all generated `impl` blocks for improved tooling support
+- **BREAKING**: `#[lorm(is_set = ...)]` now expects a callable path (e.g. `Uuid::is_nil`) instead of a method-call expression (e.g. `is_nil()`). The callable is invoked as `(callable)(&value)` and must return `bool`. The default behavior (compare with `Default::default()`) is unchanged when `is_set` is omitted.
+
+  Migration:
+  ```diff
+  - #[lorm(is_set = "is_nil()")]
+  + #[lorm(is_set = "Uuid::is_nil")]
+  ```
 
 ## [0.2.2] - 2025-12-15
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Lorm provides several attributes to customize code generation. Attributes can be
 | `#[lorm(created_at)]` | Marks field as creation timestamp | `#[lorm(created_at)]`<br>`pub created_at: DateTime` | Auto-set on INSERT |
 | `#[lorm(updated_at)]` | Marks field as update timestamp | `#[lorm(updated_at)]`<br>`pub updated_at: DateTime` | Auto-set on INSERT and UPDATE |
 | `#[lorm(new="expr")]` | Custom expression to generate field value | `#[lorm(new="Uuid::new_v4()")]` | Used in INSERT queries |
-| `#[lorm(is_set="fn()")]` | Custom function to check if field has a value | `#[lorm(is_set="is_nil()")]` | Used to determine INSERT vs UPDATE |
+| `#[lorm(is_set="path")]` | Callable path to check if field has a value — invoked as `(path)(&field)`, must return `bool` | `#[lorm(is_set="Uuid::is_nil")]` | Used to determine INSERT vs UPDATE |
 | `#[lorm(rename="name")]` | Renames field to specific column name | `#[lorm(rename="user_email")]` | Uses custom column name |
 
 #### Struct-Level Attributes

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 struct Account {
     #[lorm(pk)]
     #[lorm(new = "Uuid::new_v4()")]
-    #[lorm(is_set = "is_nil()")]
+    #[lorm(is_set = "Uuid::is_nil")]
     pub id: Uuid,
 
     #[lorm(by)]

--- a/lorm-macros/src/attributes.rs
+++ b/lorm-macros/src/attributes.rs
@@ -1,5 +1,6 @@
 use darling::FromField;
 use darling::FromMeta;
+use darling::util::Callable;
 use darling::util::Flag;
 use darling::{FromAttributes, FromDeriveInput};
 use heck::ToSnakeCase;
@@ -43,7 +44,7 @@ struct ColumnPropertyAttrs {
     #[darling(rename = "new")]
     new_expression: Option<Expr>,
     #[darling(rename = "is_set")]
-    is_set_expression: Option<Expr>,
+    is_set_expression: Option<Callable>,
 }
 
 #[derive(Debug, Clone)]
@@ -68,11 +69,12 @@ pub struct ColumnProperties {
 
     /// The expression to use to generate a new value for the field. Used when generating a new primary key or the `created_at` and `updated_at` fields.
     pub new_expression: Expr,
-    /// A field or method call that is accessed/executed with the field as the receiver to determine whether the field is set.
+    /// A callable path used to determine whether the field is set (e.g. `Uuid::is_nil`).
+    /// Invoked as `(callable)(&field_value)` and must return `bool`.
     /// If not set, the field's value will be compared with [Default::default].
     ///
     /// Used to determine whether the instance is in the database or not
-    pub is_set_expression: Option<Expr>,
+    pub is_set_expression: Option<Callable>,
 }
 
 #[derive(Debug, FromAttributes)]
@@ -138,8 +140,8 @@ impl ColumnProperties {
 
     pub fn is_set(&self, base: TokenStream, ty: &Type) -> TokenStream {
         match &self.is_set_expression {
-            Some(expr) => quote! {#base.#expr},
-            None => quote! {*#base == #ty::default()},
+            Some(callable) => quote! { (#callable)(#base) },
+            None => quote! { (|val: &#ty| val == &<#ty as Default>::default())(#base) },
         }
     }
 }

--- a/lorm-macros/src/lib.rs
+++ b/lorm-macros/src/lib.rs
@@ -15,7 +15,7 @@ mod utils;
 ///  Annotated field is marked as being the primary key and can only be generated at insertion time.
 ///  This field is also automatically considered as a `#[lorm(by)]` field.
 ///  - If `#[lorm(new)]` is specified, it will use its struct method to generate a new pk at insertion time
-///  - If `#[lorm(is_set)]` is specified, it will use its instance method against `self` to check if the pk is set. Otherwise it compares the pk value with its <struct>::default() (assuming the Default trait is set)
+///  - If `#[lorm(is_set)]` is specified, it will invoke the callable as `(callable)(&pk_value)` to check if the pk is set. Otherwise it compares the pk value with `Default::default()`.
 ///  - If `#[lorm(readonly)]` is specified, it will ignore is_set `#[lorm(new)]` and `#[lorm(is_set)]` and let the database handles the field
 ///
 /// `#[lorm(rename="name")]`
@@ -58,10 +58,10 @@ mod utils;
 ///  - The function call is expected to return an instance
 ///  - When not provided, the type::new() method is called
 ///
-/// `#[lorm(is_set="is_nil()")]`
-///  Uses a specific function call to check if the returned value if the default value.
-///  The function call is expected to return bool.
-///  Defaults to class_type::default() which assumes both the Default and PartialEq trait are implemented.
+/// `#[lorm(is_set="Uuid::is_nil")]`
+///  Uses a callable path to check if the field has its default (unset) value.
+///  Invoked as `(callable)(&field_value)` and must return `bool`.
+///  Defaults to comparing with `Default::default()` (requires `Default + PartialEq`).
 ///
 #[proc_macro_derive(ToLOrm,
     attributes(
@@ -71,7 +71,7 @@ mod utils;
         // lorm(skip),
         // lorm(readonly),
         // lorm(new="module::path::class::new_custom()"),
-        // lorm(is_set="is_nil()"),
+        // lorm(is_set="Uuid::is_nil"),
         // lorm(rename="name"),
         // lorm(created_at),
         // lorm(updated_at),

--- a/lorm/tests/main.rs
+++ b/lorm/tests/main.rs
@@ -37,7 +37,7 @@ mod models {
         #[lorm(pk)]
         #[lorm(new = "Uuid::new_v4()")]
         // Default is used but a boolean check function can also be used.
-        #[lorm(is_set = "is_nil()")]
+        #[lorm(is_set = "Uuid::is_nil")]
         pub id: Uuid,
 
         #[lorm(by)]
@@ -98,7 +98,7 @@ mod models {
         #[lorm(pk)]
         #[lorm(new = "Uuid::new_v4()")]
         // Default is used but a boolean check function can also be used.
-        #[lorm(is_set = "is_nil()")]
+        #[lorm(is_set = "Uuid::is_nil")]
         pub id: Uuid,
 
         #[lorm(by)]


### PR DESCRIPTION
## Summary

- Migrates `#[lorm(is_set = ...)]` from `syn::Expr` (method-call syntax) to `darling::util::Callable` (path syntax)
- The callable is invoked as `(callable)(&field_value)` and must return `bool`
- Default behavior (compare with `Default::default()`) is unchanged when `is_set` is omitted

## Breaking Change

```diff
- #[lorm(is_set = "is_nil()")]
+ #[lorm(is_set = "Uuid::is_nil")]
```

Old method-call syntax (`"is_nil()"`) now fails at compile time with a darling parse error.

## Commits

1. `feat(macros)!: migrate is_set attribute to darling Callable` — `lorm-macros/src/attributes.rs`
2. `test: update test models for new is_set Callable syntax` — `lorm/tests/main.rs`
3. `docs: update README and CHANGELOG for is_set Callable migration` — `README.md`, `CHANGELOG.md`, `lorm-macros/src/lib.rs`

BREAKING CHANGE: #[lorm(is_set = "is_nil()")] becomes #[lorm(is_set = "Uuid::is_nil")]