### PR TITLE
feat(macros): support #[sqlx(json)] attribute for JSON column binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Support `#[sqlx(json)]` attribute on fields. Lorm wraps bind values with `sqlx::types::Json` automatically. The bare `#[sqlx(json)]` form is supported; `#[sqlx(json(nullable))]` is not supported in this release. A field with `#[sqlx(json)]` cannot be the primary key.
+
 ### Fixed
 
 - Correct error message for `#[lorm(new = "...")]` attribute: previously said "is_set attribute" instead of "new attribute"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Lorm provides several attributes to customize code generation. Attributes can be
 | `#[lorm(new="expr")]` | Custom expression to generate field value | `#[lorm(new="Uuid::new_v4()")]` | Used in INSERT queries |
 | `#[lorm(is_set="path")]` | Callable path to check if field has a value — invoked as `(path)(&field)`, must return `bool` | `#[lorm(is_set="Uuid::is_nil")]` | Used to determine INSERT vs UPDATE |
 | `#[lorm(rename="name")]` | Renames field to specific column name | `#[lorm(rename="user_email")]` | Uses custom column name |
+| `#[sqlx(json)]` | Serialises the field as JSON when writing and deserialises it when reading. Lorm wraps bind values with `sqlx::types::Json` automatically. Cannot be combined with `#[lorm(pk)]`. | `#[sqlx(json)]`<br>`pub preferences: serde_json::Value` | Field stored as JSON/JSONB/TEXT depending on backend |
 
 #### Struct-Level Attributes
 
@@ -357,6 +358,22 @@ cargo expand --test main
 ### Does Lorm work with connection pools?
 
 Yes! Lorm works with SQLx connection pools (`&Pool`) on all backends. On SQLite and PostgreSQL, it also works with transactions (`&mut Transaction`). On MySQL, the `save()` method requires a `Copy` executor, so it only works with `&Pool`.
+
+### How do I store JSON data?
+
+Use `#[sqlx(json)]` on a field typed as `serde_json::Value` (or any `serde::Serialize + serde::Deserialize` type). Lorm wraps the bind value with `sqlx::types::Json` on write and SQLx's `FromRow` derive deserialises it on read.
+
+```rust
+#[derive(Debug, Default, FromRow, ToLOrm)]
+struct Profile {
+    #[lorm(pk, new = "Uuid::new_v4()")]
+    pub id: Uuid,
+    #[sqlx(json)]
+    pub preferences: serde_json::Value,
+}
+```
+
+The underlying column type should be `TEXT` for SQLite, `JSONB` for PostgreSQL, and `JSON` for MySQL. A field with `#[sqlx(json)]` cannot be the primary key.
 
 ### How do I handle composite primary keys?
 

--- a/lorm-macros/src/attributes.rs
+++ b/lorm-macros/src/attributes.rs
@@ -84,6 +84,7 @@ pub struct ColumnProperties {
 pub struct SqlxColumnAttributes {
     pub skip: Flag,
     pub rename: Option<String>,
+    #[darling(rename = "json")]
     pub is_json: Flag,
 }
 

--- a/lorm-macros/src/attributes.rs
+++ b/lorm-macros/src/attributes.rs
@@ -75,6 +75,8 @@ pub struct ColumnProperties {
     ///
     /// Used to determine whether the instance is in the database or not
     pub is_set_expression: Option<Callable>,
+
+    pub use_json: bool,
 }
 
 #[derive(Debug, FromAttributes)]
@@ -82,6 +84,7 @@ pub struct ColumnProperties {
 pub struct SqlxColumnAttributes {
     pub skip: Flag,
     pub rename: Option<String>,
+    pub is_json: Flag,
 }
 
 fn parse_sqlx_attrs(attrs: Vec<Attribute>) -> Result<SqlxColumnAttributes, darling::Error> {
@@ -125,6 +128,12 @@ impl ColumnProperties {
                 "The `is_set` attribute only makes sense on generated primary key fields.",
             ));
         }
+        if value.is_primary_key.is_present() && sqlx.is_json.is_present() {
+            return Err(syn::Error::new(
+                field.span(),
+                "A field annotated with #[sqlx(json)] cannot be the primary key.",
+            ));
+        }
 
         Ok(ColumnProperties {
             skip: sqlx.skip.is_present(),
@@ -135,6 +144,7 @@ impl ColumnProperties {
             updated_at: value.is_updated_at.is_present(),
             new_expression: value.new_expression.unwrap_or_else(default_new_expression),
             is_set_expression: value.is_set_expression,
+            use_json: sqlx.is_json.is_present(),
         })
     }
 

--- a/lorm-macros/src/orm/by.rs
+++ b/lorm-macros/src/orm/by.rs
@@ -1,5 +1,7 @@
 use crate::models::OrmModel;
-use crate::utils::{db_placeholder, get_bind_param_type_and_usage, get_bind_type_where_constraint};
+use crate::utils::{
+    db_placeholder, get_bind_param_type_and_usage, get_bind_type_where_constraint, to_column_type,
+};
 use quote::{__private::TokenStream, format_ident, quote};
 
 pub fn generate_by(
@@ -18,13 +20,25 @@ pub fn generate_by(
 
         let lifetime = quote! {'a};
         let parameter = quote! {value};
-        let field_type_constraints = get_bind_type_where_constraint(&column.ty, database_type, &lifetime).unwrap();
         let (param_type, param_value) = get_bind_param_type_and_usage(&parameter, &column.ty, &lifetime).unwrap();
         let by_fn = format_ident!("by_{}", field_name);
 
         let columns = model.full_column_select();
         let placeholder = db_placeholder(column.base_field, 1).unwrap();
         let sql_ident = format!("SELECT {columns} FROM {table_name} WHERE {column_name} = {placeholder}");
+
+        let field_type_constraints = if column.column_properties.use_json {
+            let base_type = to_column_type(&column.ty).unwrap();
+            quote! { #base_type: serde::Serialize }
+        } else {
+            get_bind_type_where_constraint(&column.ty, database_type, &lifetime).unwrap()
+        };
+
+        let bind_value = if column.column_properties.use_json {
+            quote! { sqlx::types::Json(#param_value) }
+        } else {
+            param_value.clone()
+        };
 
         let signature = quote! {
             async fn #by_fn<#lifetime>(executor: E, #parameter: #param_type) -> lorm::errors::Result<#struct_name> where #field_type_constraints
@@ -37,7 +51,7 @@ pub fn generate_by(
         let impl_code = quote! {
             #signature {
                 let r = sqlx::query_as::<_, #struct_name>(#sql_ident)
-                    .bind(#param_value)
+                    .bind(#bind_value)
                     .fetch_one(executor).await?;
                 Ok(r)
             }

--- a/lorm-macros/src/orm/save.rs
+++ b/lorm-macros/src/orm/save.rs
@@ -73,7 +73,12 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
         } else if column.column_properties.primary_key {
             primary_key_var.clone()
         } else {
-            column.self_accessor()
+            let accessor = column.self_accessor();
+            if column.column_properties.use_json {
+                quote! { sqlx::types::Json(#accessor) }
+            } else {
+                accessor
+            }
         }
     };
 

--- a/lorm-macros/src/orm/with.rs
+++ b/lorm-macros/src/orm/with.rs
@@ -1,5 +1,7 @@
 use crate::models::OrmModel;
-use crate::utils::{db_placeholder, get_bind_param_type_and_usage, get_bind_type_where_constraint};
+use crate::utils::{
+    db_placeholder, get_bind_param_type_and_usage, get_bind_type_where_constraint, to_column_type,
+};
 use quote::{__private::TokenStream, format_ident, quote};
 
 pub fn generate_with(
@@ -18,10 +20,21 @@ pub fn generate_with(
         let column_name = &column.column_name;
 
         let lifetime = quote! {'a};
-
-        let constraints = get_bind_type_where_constraint(&column.ty, database_type, &lifetime).unwrap();
         let param = quote! {value};
         let (param_type, param_value) = get_bind_param_type_and_usage(&param, &column.ty, &lifetime)?;
+
+        let constraints = if column.column_properties.use_json {
+            let base_type = to_column_type(&column.ty).unwrap();
+            quote! { #base_type: serde::Serialize }
+        } else {
+            get_bind_type_where_constraint(&column.ty, database_type, &lifetime).unwrap()
+        };
+
+        let bind_value = if column.column_properties.use_json {
+            quote! { sqlx::types::Json(#param_value) }
+        } else {
+            param_value.clone()
+        };
 
         let with_fn = format_ident!("with_{}",field_name);
         let placeholder = db_placeholder(column.base_field, 1).unwrap();
@@ -37,7 +50,7 @@ pub fn generate_with(
         let impl_code = quote! {
             #signature {
                 let r = sqlx::query_as::<_, Self>(#sql_ident)
-                    .bind(#param_value)
+                    .bind(#bind_value)
                     .fetch_all(executor).await?;
                 Ok(r)
             }

--- a/lorm/Cargo.toml
+++ b/lorm/Cargo.toml
@@ -29,11 +29,12 @@ thiserror = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "chrono", "derive", "uuid", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "chrono", "derive", "uuid", "migrate", "json"] }
 chrono = { workspace = true, features = ["std", "serde"] }
 uuid = { workspace = true, features = ["std", "serde", "v4"] }
 fake = { workspace = true }
 anyhow = { workspace = true }
+serde_json = "1.0"
 
 [[example]]
 name = "basic_crud"

--- a/lorm/tests/main.rs
+++ b/lorm/tests/main.rs
@@ -84,6 +84,18 @@ mod models {
         #[lorm(new = "chrono::Utc::now().fixed_offset()")]
         pub updated_at: chrono::DateTime<FixedOffset>,
     }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, ToLOrm)]
+    pub struct Profile {
+        #[lorm(pk)]
+        #[lorm(new = "Uuid::new_v4()")]
+        #[lorm(is_set = "Uuid::is_nil")]
+        pub id: Uuid,
+        #[lorm(by)]
+        pub user_id: Uuid,
+        #[sqlx(json)]
+        pub preferences: serde_json::Value,
+    }
 }
 
 #[cfg(feature = "mysql")]
@@ -144,6 +156,18 @@ mod models {
         #[lorm(updated_at)]
         #[lorm(new = "chrono::Utc::now()")]
         pub updated_at: chrono::DateTime<Utc>,
+    }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, ToLOrm)]
+    pub struct Profile {
+        #[lorm(pk)]
+        #[lorm(new = "Uuid::new_v4()")]
+        #[lorm(is_set = "Uuid::is_nil")]
+        pub id: Uuid,
+        #[lorm(by)]
+        pub user_id: Uuid,
+        #[sqlx(json)]
+        pub preferences: serde_json::Value,
     }
 }
 
@@ -573,4 +597,31 @@ async fn create_alt_users<'e, E: sqlx::MySqlExecutor<'e> + Copy>(
         users.push(u);
     }
     users
+}
+
+#[tokio::test]
+async fn test_profile_save_with_json() {
+    let pool = get_pool().await.expect("Failed to create pool");
+    let profile = Profile {
+        user_id: Uuid::new_v4(),
+        preferences: serde_json::json!({"theme": "dark", "lang": "en"}),
+        ..Default::default()
+    };
+    let saved = profile.save(&pool).await.unwrap();
+    assert_ne!(saved.id, Uuid::nil());
+    assert_eq!(saved.preferences["theme"], "dark");
+}
+
+#[tokio::test]
+async fn test_profile_by_user_id_returns_json() {
+    let pool = get_pool().await.expect("Failed to create pool");
+    let user_id = Uuid::new_v4();
+    let profile = Profile {
+        user_id,
+        preferences: serde_json::json!({"color": "blue"}),
+        ..Default::default()
+    };
+    let saved = profile.save(&pool).await.unwrap();
+    let fetched = Profile::by_user_id(&pool, &saved.user_id).await.unwrap();
+    assert_eq!(fetched.preferences["color"], "blue");
 }

--- a/lorm/tests/resources/migrations/mysql/04_profiles_table.sql
+++ b/lorm/tests/resources/migrations/mysql/04_profiles_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS profiles (
-    id CHAR(36) NOT NULL PRIMARY KEY,
-    user_id CHAR(36) NOT NULL,
+    id BINARY(16) NOT NULL PRIMARY KEY,
+    user_id BINARY(16) NOT NULL,
     preferences JSON NOT NULL
 );

--- a/lorm/tests/resources/migrations/mysql/04_profiles_table.sql
+++ b/lorm/tests/resources/migrations/mysql/04_profiles_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS profiles (
+    id CHAR(36) NOT NULL PRIMARY KEY,
+    user_id CHAR(36) NOT NULL,
+    preferences JSON NOT NULL
+);

--- a/lorm/tests/resources/migrations/postgres/04_profiles_table.sql
+++ b/lorm/tests/resources/migrations/postgres/04_profiles_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS profiles (
+    id UUID NOT NULL PRIMARY KEY,
+    user_id UUID NOT NULL,
+    preferences JSONB NOT NULL
+);

--- a/lorm/tests/resources/migrations/sqlite/04_profiles_table.sql
+++ b/lorm/tests/resources/migrations/sqlite/04_profiles_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS profiles (
+    id TEXT NOT NULL PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    preferences TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary

- Adds `#[sqlx(json)]` attribute support: parse via darling `Flag` in `SqlxColumnAttributes.is_json` and store as `ColumnProperties.use_json`
- Wrap field bind values with `sqlx::types::Json(...)` in `save.rs` (insert + update), `by.rs`, and `with.rs` when `use_json` is set
- Validate at compile time that `#[sqlx(json)]` and `#[lorm(pk)]` cannot coexist on the same field
- Add `Profile` model with `preferences: serde_json::Value` to tests for all 3 backends; add `04_profiles_table.sql` migrations (SQLite: TEXT, PostgreSQL: JSONB, MySQL: JSON)
- Add `serde_json = "1.0"` and `sqlx json` feature to `[dev-dependencies]`
- Document `#[sqlx(json)]` in README attribute table and FAQ; add CHANGELOG entry

## Testing

All 15 SQLite tests pass including new `test_profile_save_with_json` and `test_profile_by_user_id_returns_json`. Compile-time rejection of `#[sqlx(json)]` on primary key verified.