### PR TITLE
feat(macros): support #[sqlx(flatten)] with #[lorm(flattened(...))]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Support `#[sqlx(json)]` attribute on fields. Lorm wraps bind values with `sqlx::types::Json` automatically. The bare `#[sqlx(json)]` form is supported; `#[sqlx(json(nullable))]` is not supported in this release. A field with `#[sqlx(json)]` cannot be the primary key.
+- Support flattened nested structs via `#[sqlx(flatten)]` used together with `#[lorm(flattened(field: Type, field2: Type = "renamed_col"))]`.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "fake",
  "lorm-macros",
  "serde",
+ "serde_json",
  "sqlx",
  "thiserror",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -121,6 +121,46 @@ Lorm provides several attributes to customize code generation. Attributes can be
 | `#[lorm(is_set="path")]` | Callable path to check if field has a value — invoked as `(path)(&field)`, must return `bool` | `#[lorm(is_set="Uuid::is_nil")]` | Used to determine INSERT vs UPDATE |
 | `#[lorm(rename="name")]` | Renames field to specific column name | `#[lorm(rename="user_email")]` | Uses custom column name |
 | `#[sqlx(json)]` | Serialises the field as JSON when writing and deserialises it when reading. Lorm wraps bind values with `sqlx::types::Json` automatically. Cannot be combined with `#[lorm(pk)]`. | `#[sqlx(json)]`<br>`pub preferences: serde_json::Value` | Field stored as JSON/JSONB/TEXT depending on backend |
+| `#[sqlx(flatten)]` + `#[lorm(flattened(...))]` | Flattens a nested struct field into multiple SQL columns. Requires both attributes. For optional nested structs, use `Option<Nested>`. | `#[sqlx(flatten)]`<br>`#[lorm(flattened(street: String, zip: String = "zip_code"))]`<br>`pub address: Address` | Nested field is expanded into multiple columns |
+
+#### Flattened Nested Structs
+
+Use `#[sqlx(flatten)]` together with `#[lorm(flattened(...))]` to map a nested struct field to multiple SQL columns.
+
+```rust
+#[derive(Debug, Default, Clone, sqlx::FromRow)]
+pub struct Address {
+    pub street: String,
+    #[sqlx(rename = "zip_code")]
+    pub zip: String,
+}
+
+#[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+pub struct Customer {
+    #[lorm(pk, new = "Uuid::new_v4()", is_set = "Uuid::is_nil")]
+    pub id: Uuid,
+    #[lorm(by)]
+    pub email: String,
+    #[sqlx(flatten)]
+    #[lorm(flattened(street: String, zip: String = "zip_code"))]
+    pub address: Address,
+}
+```
+
+To represent nullable flattened columns, use `Option<NestedStruct>`:
+
+```rust
+#[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+pub struct OptCustomer {
+    #[lorm(pk, new = "Uuid::new_v4()", is_set = "Uuid::is_nil")]
+    pub id: Uuid,
+    #[lorm(by)]
+    pub email: String,
+    #[sqlx(flatten)]
+    #[lorm(flattened(street: String, zip: String = "zip_code"))]
+    pub address: Option<Address>,
+}
+```
 
 #### Struct-Level Attributes
 

--- a/lorm-macros/src/attributes.rs
+++ b/lorm-macros/src/attributes.rs
@@ -9,7 +9,7 @@ use quote::quote;
 use syn::Expr;
 use syn::Field;
 use syn::spanned::Spanned;
-use syn::{Attribute, DeriveInput, Type};
+use syn::{Attribute, DeriveInput, Ident, Type};
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(lorm), supports(struct_named))]
@@ -29,6 +29,57 @@ impl TableAttributes {
     }
 }
 
+/// Represents one field entry in `#[lorm(flattened(field: Type, field2: Type = "renamed_col"))]`
+#[derive(Debug, Clone)]
+pub(crate) struct FlattenedField {
+    pub(crate) ident: Ident,
+    pub(crate) ty: Type,
+    pub(crate) column_name: String,
+}
+
+impl syn::parse::Parse for FlattenedField {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let ident: Ident = input.parse()?;
+        input.parse::<syn::Token![:]>()?;
+        let ty: Type = input.parse()?;
+        let column_name = if input.peek(syn::Token![=]) {
+            input.parse::<syn::Token![=]>()?;
+            let s: syn::LitStr = input.parse()?;
+            s.value()
+        } else {
+            ident.to_string()
+        };
+        Ok(FlattenedField {
+            ident,
+            ty,
+            column_name,
+        })
+    }
+}
+
+/// Parsed form of `#[lorm(flattened(field1: Type1, field2: Type2 = "col_name", ...))]`
+#[derive(Debug, Clone)]
+pub(crate) struct FlattenedFields {
+    pub(crate) fields: Vec<FlattenedField>,
+}
+
+impl darling::FromMeta for FlattenedFields {
+    fn from_meta(item: &syn::Meta) -> darling::Result<Self> {
+        if let syn::Meta::List(list) = item {
+            let fields: syn::punctuated::Punctuated<FlattenedField, syn::Token![,]> = list
+                .parse_args_with(syn::punctuated::Punctuated::parse_terminated)
+                .map_err(|e| darling::Error::custom(e.to_string()))?;
+            Ok(FlattenedFields {
+                fields: fields.into_iter().collect(),
+            })
+        } else {
+            Err(darling::Error::custom(
+                "expected list: #[lorm(flattened(field: Type, field2: Type = \"col_name\"))]",
+            ))
+        }
+    }
+}
+
 #[derive(Debug, FromMeta)]
 struct ColumnPropertyAttrs {
     #[darling(rename = "pk")]
@@ -45,6 +96,9 @@ struct ColumnPropertyAttrs {
     new_expression: Option<Expr>,
     #[darling(rename = "is_set")]
     is_set_expression: Option<Callable>,
+
+    #[darling(rename = "flattened")]
+    flattened_fields: Option<FlattenedFields>,
 }
 
 #[derive(Debug, Clone)]
@@ -86,6 +140,8 @@ pub struct SqlxColumnAttributes {
     pub rename: Option<String>,
     #[darling(rename = "json")]
     pub is_json: Flag,
+
+    pub flatten: Flag,
 }
 
 fn parse_sqlx_attrs(attrs: Vec<Attribute>) -> Result<SqlxColumnAttributes, darling::Error> {
@@ -99,6 +155,45 @@ pub struct FieldAttributes {
     field_properties: ColumnPropertyAttrs,
     #[darling(with = "parse_sqlx_attrs")]
     attrs: SqlxColumnAttributes,
+}
+
+impl FieldAttributes {
+    pub(crate) fn has_sqlx_flatten(&self) -> bool {
+        self.attrs.flatten.is_present()
+    }
+
+    pub(crate) fn has_lorm_flattened(&self) -> bool {
+        self.field_properties.flattened_fields.is_some()
+    }
+
+    pub(crate) fn is_skip(&self) -> bool {
+        self.attrs.skip.is_present()
+    }
+
+    pub(crate) fn is_primary_key(&self) -> bool {
+        self.field_properties.is_primary_key.is_present()
+    }
+
+    pub(crate) fn is_created_at_field(&self) -> bool {
+        self.field_properties.is_created_at.is_present()
+    }
+
+    pub(crate) fn is_updated_at_field(&self) -> bool {
+        self.field_properties.is_updated_at.is_present()
+    }
+
+    pub(crate) fn flatten_generate_by(&self) -> bool {
+        self.field_properties.generate_by.is_present()
+    }
+
+    pub(crate) fn flatten_readonly(&self) -> bool {
+        self.field_properties.readonly.is_present()
+    }
+
+    /// Consumes self and returns the FlattenedFields. Only call if `has_lorm_flattened()` is true.
+    pub(crate) fn take_flattened_fields(self) -> FlattenedFields {
+        self.field_properties.flattened_fields.unwrap()
+    }
 }
 
 fn default_new_expression() -> Expr {

--- a/lorm-macros/src/lib.rs
+++ b/lorm-macros/src/lib.rs
@@ -66,6 +66,7 @@ mod utils;
 #[proc_macro_derive(ToLOrm,
     attributes(
         lorm,
+        sqlx,
         // lorm(pk),
         // lorm(by),
         // lorm(skip),

--- a/lorm-macros/src/models.rs
+++ b/lorm-macros/src/models.rs
@@ -1,12 +1,16 @@
+use crate::attributes::ColumnProperties;
 use crate::attributes::FieldAttributes;
 use crate::attributes::FieldProperties;
 use crate::attributes::TableAttributes;
 use crate::orm::column::Column;
+use crate::utils::is_option_wrapped;
 use darling::FromDeriveInput;
 use darling::FromField;
 use quote::ToTokens;
+use quote::quote;
 use syn::parse;
 use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{DeriveInput, Field, Ident, Visibility};
 
@@ -122,7 +126,87 @@ impl<'a> OrmModel<'a> {
 }
 
 fn process_struct_field<'a>(field: &'a Field, columns: &mut Vec<Column<'a>>) -> syn::Result<()> {
-    let properties = FieldProperties::from(field, FieldAttributes::from_field(field)?)?;
+    let field_attrs = FieldAttributes::from_field(field)?;
+
+    let has_sqlx_flatten = field_attrs.has_sqlx_flatten();
+    let has_lorm_flattened = field_attrs.has_lorm_flattened();
+
+    if has_sqlx_flatten || has_lorm_flattened {
+        // Both attributes must be present together
+        if has_sqlx_flatten && !has_lorm_flattened {
+            return Err(syn::Error::new(
+                field.span(),
+                "#[sqlx(flatten)] requires a matching #[lorm(flattened(field: Type, ...))] attribute",
+            ));
+        }
+        if !has_sqlx_flatten && has_lorm_flattened {
+            return Err(syn::Error::new(
+                field.span(),
+                "#[lorm(flattened(...))] requires a matching #[sqlx(flatten)] attribute",
+            ));
+        }
+
+        // Reject incompatible parent attributes
+        if field_attrs.is_primary_key() {
+            return Err(syn::Error::new(
+                field.span(),
+                "A flattened field cannot be the primary key.",
+            ));
+        }
+        if field_attrs.is_created_at_field() {
+            return Err(syn::Error::new(
+                field.span(),
+                "A flattened field cannot be #[lorm(created_at)].",
+            ));
+        }
+        if field_attrs.is_updated_at_field() {
+            return Err(syn::Error::new(
+                field.span(),
+                "A flattened field cannot be #[lorm(updated_at)].",
+            ));
+        }
+
+        if field_attrs.is_skip() {
+            return Ok(()); // Parent skipped → skip all nested fields
+        }
+
+        let generate_by = field_attrs.flatten_generate_by();
+        let readonly = field_attrs.flatten_readonly();
+        let flattened_fields = field_attrs.take_flattened_fields();
+        let parent_is_option = is_option_wrapped(&field.ty);
+        for entry in flattened_fields.fields {
+            let ty = if parent_is_option {
+                let inner = entry.ty;
+                syn::parse2(quote! { Option<#inner> })?
+            } else {
+                entry.ty
+            };
+            let col_props = ColumnProperties {
+                skip: false,
+                readonly,
+                primary_key: false,
+                generate_by,
+                created_at: false,
+                updated_at: false,
+                new_expression: syn::parse_str("Default::default()").unwrap(),
+                is_set_expression: None,
+                use_json: false,
+            };
+
+            columns.push(Column {
+                base_field: field,
+                field: entry.ident,
+                ty,
+                is_flattened: true,
+                column_name: entry.column_name,
+                column_properties: col_props,
+            });
+        }
+
+        return Ok(());
+    }
+
+    let properties = FieldProperties::from(field, field_attrs)?;
 
     if properties.column_properties.skip {
         return Ok(());

--- a/lorm/tests/main.rs
+++ b/lorm/tests/main.rs
@@ -32,6 +32,13 @@ mod models {
     use sqlx::FromRow;
     use uuid::Uuid;
 
+    #[derive(Debug, Default, Clone, sqlx::FromRow)]
+    pub struct Address {
+        pub street: String,
+        #[sqlx(rename = "zip_code")]
+        pub zip: String,
+    }
+
     #[derive(Debug, Default, Clone, FromRow, ToLOrm)]
     pub struct User {
         #[lorm(pk)]
@@ -95,6 +102,82 @@ mod models {
         pub user_id: Uuid,
         #[sqlx(json)]
         pub preferences: serde_json::Value,
+    }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+    pub struct Customer {
+        #[lorm(pk)]
+        #[lorm(new = "Uuid::new_v4()")]
+        #[lorm(is_set = "Uuid::is_nil")]
+        pub id: Uuid,
+        #[lorm(by)]
+        pub email: String,
+        #[sqlx(flatten)]
+        #[lorm(flattened(street: String, zip: String = "zip_code"))]
+        pub address: Address,
+    }
+
+    #[derive(Debug, Default, Clone, lorm::ToLOrm)]
+    pub struct OptCustomer {
+        #[lorm(pk)]
+        #[lorm(new = "Uuid::new_v4()")]
+        #[lorm(is_set = "Uuid::is_nil")]
+        pub id: Uuid,
+        #[lorm(by)]
+        pub email: String,
+        #[sqlx(flatten)]
+        #[lorm(flattened(street: String, zip: String = "zip_code"))]
+        pub address: Option<Address>,
+    }
+
+    #[cfg(feature = "sqlite")]
+    impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for OptCustomer {
+        fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
+            use sqlx::Row;
+
+            let id: Uuid = row.try_get("id")?;
+            let email: String = row.try_get("email")?;
+            let street: Option<String> = row.try_get("street")?;
+            let zip: Option<String> = row.try_get("zip_code")?;
+            let address = match (street, zip) {
+                (None, None) => None,
+                (Some(street), Some(zip)) => Some(Address { street, zip }),
+                _ => {
+                    let err = std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "partial NULL in flattened Option<Address>",
+                    );
+                    return Err(sqlx::Error::Decode(Box::new(err)));
+                }
+            };
+
+            Ok(Self { id, email, address })
+        }
+    }
+
+    #[cfg(feature = "postgres")]
+    impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for OptCustomer {
+        fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
+            use sqlx::Row;
+
+            let id: Uuid = row.try_get("id")?;
+            let email: String = row.try_get("email")?;
+            let street: Option<String> = row.try_get("street")?;
+            let zip: Option<String> = row.try_get("zip_code")?;
+            let address = match (street, zip) {
+                (None, None) => None,
+                (Some(street), Some(zip)) => Some(Address { street, zip }),
+                _ => {
+                    let err = std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "partial NULL in flattened Option<Address>",
+                    );
+                    return Err(sqlx::Error::Decode(Box::new(err)));
+                }
+            };
+
+            Ok(Self { id, email, address })
+        }
     }
 }
 
@@ -105,6 +188,13 @@ mod models {
     use sqlx::FromRow;
     use uuid::Uuid;
 
+    #[derive(Debug, Default, Clone, sqlx::FromRow)]
+    pub struct Address {
+        pub street: String,
+        #[sqlx(rename = "zip_code")]
+        pub zip: String,
+    }
+
     #[derive(Debug, Default, Clone, FromRow, ToLOrm)]
     pub struct User {
         #[lorm(pk)]
@@ -168,6 +258,56 @@ mod models {
         pub user_id: Uuid,
         #[sqlx(json)]
         pub preferences: serde_json::Value,
+    }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+    pub struct Customer {
+        #[lorm(pk)]
+        #[lorm(new = "Uuid::new_v4()")]
+        #[lorm(is_set = "Uuid::is_nil")]
+        pub id: Uuid,
+        #[lorm(by)]
+        pub email: String,
+        #[sqlx(flatten)]
+        #[lorm(flattened(street: String, zip: String = "zip_code"))]
+        pub address: Address,
+    }
+
+    #[derive(Debug, Default, Clone, lorm::ToLOrm)]
+    pub struct OptCustomer {
+        #[lorm(pk)]
+        #[lorm(new = "Uuid::new_v4()")]
+        #[lorm(is_set = "Uuid::is_nil")]
+        pub id: Uuid,
+        #[lorm(by)]
+        pub email: String,
+        #[sqlx(flatten)]
+        #[lorm(flattened(street: String, zip: String = "zip_code"))]
+        pub address: Option<Address>,
+    }
+
+    impl<'r> sqlx::FromRow<'r, sqlx::mysql::MySqlRow> for OptCustomer {
+        fn from_row(row: &'r sqlx::mysql::MySqlRow) -> Result<Self, sqlx::Error> {
+            use sqlx::Row;
+
+            let id: Uuid = row.try_get("id")?;
+            let email: String = row.try_get("email")?;
+            let street: Option<String> = row.try_get("street")?;
+            let zip: Option<String> = row.try_get("zip_code")?;
+            let address = match (street, zip) {
+                (None, None) => None,
+                (Some(street), Some(zip)) => Some(Address { street, zip }),
+                _ => {
+                    let err = std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "partial NULL in flattened Option<Address>",
+                    );
+                    return Err(sqlx::Error::Decode(Box::new(err)));
+                }
+            };
+
+            Ok(Self { id, email, address })
+        }
     }
 }
 
@@ -186,9 +326,14 @@ pub async fn get_pool() -> Result<Pool> {
     Sqlite::create_database(&database_url).await?;
     let pool = Pool::connect(&database_url).await?;
     let migration_path = fs::canonicalize("tests/resources/migrations/sqlite").await?;
+    let mut entries: Vec<_> = Vec::new();
     let mut dir = fs::read_dir(migration_path).await?;
     while let Some(entry) = dir.next_entry().await? {
-        let bytes = fs::read(entry.path()).await?;
+        entries.push(entry.path());
+    }
+    entries.sort();
+    for path in entries {
+        let bytes = fs::read(&path).await?;
         let content = String::from_utf8(bytes)?;
         pool.execute(content.as_str()).await?;
     }
@@ -624,4 +769,47 @@ async fn test_profile_by_user_id_returns_json() {
     let saved = profile.save(&pool).await.unwrap();
     let fetched = Profile::by_user_id(&pool, &saved.user_id).await.unwrap();
     assert_eq!(fetched.preferences["color"], "blue");
+}
+
+#[tokio::test]
+async fn test_customer_save_with_flatten() {
+    let pool = get_pool().await.expect("Failed to create pool");
+    let mut customer = Customer::default();
+    customer.address = Address {
+        street: "123 Main St".to_string(),
+        zip: "90210".to_string(),
+    };
+    customer.email = "test@example.com".to_string();
+    customer.save(&pool).await.unwrap();
+
+    let fetched = Customer::by_email(&pool, &customer.email).await.unwrap();
+    assert_eq!(fetched.address.street, "123 Main St");
+    assert_eq!(fetched.address.zip, "90210");
+}
+
+#[tokio::test]
+async fn test_customer_by_email_returns_flattened() {
+    let pool = get_pool().await.expect("Failed to create pool");
+    let mut c1 = Customer::default();
+    c1.email = "alice@example.com".to_string();
+    c1.address = Address {
+        street: "456 Oak Ave".to_string(),
+        zip: "10001".to_string(),
+    };
+    c1.save(&pool).await.unwrap();
+
+    let result = Customer::by_email(&pool, &c1.email).await.unwrap();
+    assert_eq!(result.address.street, "456 Oak Ave");
+}
+
+#[tokio::test]
+async fn test_opt_customer_with_none_address() {
+    let pool = get_pool().await.expect("Failed to create pool");
+    let mut c = OptCustomer::default();
+    c.email = "none@example.com".to_string();
+    c.address = None;
+    c.save(&pool).await.unwrap();
+
+    let fetched = OptCustomer::by_email(&pool, &c.email).await.unwrap();
+    assert!(fetched.address.is_none());
 }

--- a/lorm/tests/resources/migrations/mysql/05_customers_table.sql
+++ b/lorm/tests/resources/migrations/mysql/05_customers_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS customers (
+    id BINARY(16) NOT NULL PRIMARY KEY,
+    email TEXT NOT NULL,
+    street TEXT NOT NULL,
+    zip_code TEXT NOT NULL
+);

--- a/lorm/tests/resources/migrations/mysql/06_opt_customers_table.sql
+++ b/lorm/tests/resources/migrations/mysql/06_opt_customers_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS opt_customers (
+    id BINARY(16) NOT NULL PRIMARY KEY,
+    email TEXT NOT NULL,
+    street TEXT,
+    zip_code TEXT
+);

--- a/lorm/tests/resources/migrations/postgres/05_customers_table.sql
+++ b/lorm/tests/resources/migrations/postgres/05_customers_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS customers (
+    id UUID NOT NULL PRIMARY KEY,
+    email TEXT NOT NULL,
+    street TEXT NOT NULL,
+    zip_code TEXT NOT NULL
+);

--- a/lorm/tests/resources/migrations/postgres/06_opt_customers_table.sql
+++ b/lorm/tests/resources/migrations/postgres/06_opt_customers_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS opt_customers (
+    id UUID NOT NULL PRIMARY KEY,
+    email TEXT NOT NULL,
+    street TEXT,
+    zip_code TEXT
+);

--- a/lorm/tests/resources/migrations/sqlite/05_customers_table.sql
+++ b/lorm/tests/resources/migrations/sqlite/05_customers_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS customers (
+    id BLOB NOT NULL PRIMARY KEY,
+    email TEXT NOT NULL,
+    street TEXT NOT NULL,
+    zip_code TEXT NOT NULL
+);

--- a/lorm/tests/resources/migrations/sqlite/06_opt_customers_table.sql
+++ b/lorm/tests/resources/migrations/sqlite/06_opt_customers_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS opt_customers (
+    id BLOB NOT NULL PRIMARY KEY,
+    email TEXT NOT NULL,
+    street TEXT,
+    zip_code TEXT
+);


### PR DESCRIPTION
## Summary
- Parse `#[sqlx(flatten)]` + `#[lorm(flattened(field: Type, ...)]` attributes
- Expand a single nested struct field into multiple SQL columns at compile time
- Support `Option<NestedStruct>` (None → all NULL columns)
- Add Customer and OptCustomer models with tests for all 3 backends
- Reject compile-time conflicts: flatten+pk, sqlx(flatten) without lorm(flattened), and vice versa

## Models Added (in tests)
- `Address` (nested struct, FromRow only)
- `Customer` (flattened Address with street/zip_code columns)
- `OptCustomer` (Optional<Address>, manual FromRow)

## Tests Added
- `test_customer_save_with_flatten`
- `test_customer_by_email_returns_flattened`
- `test_opt_customer_with_none_address`