### PR TITLE
feat: composite primary key support (manual pk_type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Support composite primary keys via `#[lorm(pk_type = "manual")]` on the struct. Mark each pk field with `#[lorm(pk)]`. A `by_key()` selector method is generated automatically (or a custom name via `#[lorm(pk_selector = "my_fn")]`).
 - Support `#[sqlx(json)]` attribute on fields. Lorm wraps bind values with `sqlx::types::Json` automatically. The bare `#[sqlx(json)]` form is supported; `#[sqlx(json(nullable))]` is not supported in this release. A field with `#[sqlx(json)]` cannot be the primary key.
 - Support flattened nested structs via `#[sqlx(flatten)]` used together with `#[lorm(flattened(field: Type, field2: Type = "renamed_col"))]`.
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ pub struct OptCustomer {
 | Attribute | Description | Example |
 |-----------|-------------|---------|
 | `#[lorm(rename="name")]` | Sets custom table name | `#[lorm(rename="app_users")]`<br>`struct User` |
+| `#[lorm(pk_type="manual")]` | Enables composite/manual primary key mode. All `#[lorm(pk)]` fields form the composite key. | `#[lorm(pk_type="manual")]`<br>`struct UserRole` |
+| `#[lorm(pk_selector="name")]` | Custom selector method name for composite pk (default: `by_key` for 2+ fields, `by_<field>` for 1 field) | `#[lorm(pk_type="manual", pk_selector="find_by_ids")]` |
 
 #### Naming Conventions
 
@@ -417,7 +419,27 @@ The underlying column type should be `TEXT` for SQLite, `JSONB` for PostgreSQL, 
 
 ### How do I handle composite primary keys?
 
-Lorm currently supports single-field primary keys only. For composite keys, use SQLx directly.
+Use `#[lorm(pk_type = "manual")]` on the struct and mark each pk field with `#[lorm(pk)]`. Lorm generates `save()`, `delete()`, and a composite selector method (`by_key()` by default, or a custom name via `pk_selector`):
+
+```rust
+#[derive(Debug, Default, sqlx::FromRow, lorm::ToLOrm)]
+#[lorm(pk_type = "manual")]
+pub struct UserRole {
+    #[lorm(pk)]
+    pub user_id: Uuid,
+    #[lorm(pk)]
+    pub role_id: Uuid,
+    pub assigned_at: String,
+}
+
+// Usage
+let ur = UserRole { user_id, role_id, assigned_at: "2024-01-01".into() };
+let saved = ur.save(&pool).await?;
+let found = UserRole::by_key(&pool, &saved.user_id, &saved.role_id).await?;
+saved.delete(&pool).await?;
+```
+
+For a custom selector name, use `#[lorm(pk_type = "manual", pk_selector = "find_by_ids")]`.
 
 ### Can I customize the SQL queries Lorm generates?
 

--- a/lorm-macros/src/attributes.rs
+++ b/lorm-macros/src/attributes.rs
@@ -11,11 +11,29 @@ use syn::Field;
 use syn::spanned::Spanned;
 use syn::{Attribute, DeriveInput, Ident, Type};
 
+/// Controls whether the primary key is generated (default) or manually managed.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, darling::FromMeta)]
+#[darling(rename_all = "lowercase")]
+pub enum PrimaryKeyType {
+    Generated,
+    Manual,
+}
+
+fn default_pk_type() -> PrimaryKeyType {
+    PrimaryKeyType::Generated
+}
+
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(lorm), supports(struct_named))]
 pub struct TableAttributes {
     #[darling(rename = "rename")]
     table_name_override: Option<String>,
+
+    #[darling(default = "default_pk_type")]
+    pub pk_type: PrimaryKeyType,
+
+    #[darling(rename = "pk_selector")]
+    pub pk_selector: Option<String>,
 }
 
 impl TableAttributes {
@@ -26,6 +44,24 @@ impl TableAttributes {
             let table_case = input.ident.to_string().to_snake_case();
             pluralizer::pluralize(table_case.as_str(), 2, false)
         })
+    }
+
+    /// Returns the method name for the composite pk selector.
+    ///
+    /// - If pk_selector is provided, use it directly.
+    /// - If single-field manual pk: use `by_<field_name>`.
+    /// - If composite pk (2+ fields): use `by_key`.
+    ///
+    /// Caller provides pk_fields to determine the name when no override.
+    pub fn pk_selector_name(&self, pk_fields: &[&str]) -> String {
+        if let Some(ident) = &self.pk_selector {
+            return ident.clone();
+        }
+        if pk_fields.len() == 1 {
+            format!("by_{}", pk_fields[0])
+        } else {
+            "by_key".to_string()
+        }
     }
 }
 

--- a/lorm-macros/src/models.rs
+++ b/lorm-macros/src/models.rs
@@ -1,6 +1,7 @@
 use crate::attributes::ColumnProperties;
 use crate::attributes::FieldAttributes;
 use crate::attributes::FieldProperties;
+use crate::attributes::PrimaryKeyType;
 use crate::attributes::TableAttributes;
 use crate::orm::column::Column;
 use crate::utils::is_option_wrapped;
@@ -14,11 +15,43 @@ use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{DeriveInput, Field, Ident, Visibility};
 
+pub(crate) enum PrimaryKey<'a> {
+    /// Single generated pk (current behavior)
+    Generated(Box<Column<'a>>),
+    /// One or more manual pk columns
+    Manual(Vec<Column<'a>>),
+}
+
+impl<'a> PrimaryKey<'a> {
+    pub(crate) fn is_generated(&self) -> bool {
+        matches!(self, PrimaryKey::Generated(_))
+    }
+
+    pub(crate) fn fields(&self) -> &[Column<'a>] {
+        match self {
+            PrimaryKey::Generated(col) => std::slice::from_ref(col.as_ref()),
+            PrimaryKey::Manual(cols) => cols,
+        }
+    }
+
+    /// For Generated pk, returns the single column.
+    /// For Manual pk, returns the first column (should not be used for composite-only logic).
+    pub(crate) fn generated_column(&self) -> &Column<'a> {
+        match self {
+            PrimaryKey::Generated(col) => col.as_ref(),
+            PrimaryKey::Manual(cols) => &cols[0],
+        }
+    }
+}
+
 pub(crate) struct OrmModel<'a> {
     pub(crate) struct_name: &'a Ident,
     pub(crate) struct_visibility: &'a Visibility,
     pub(crate) table_name: String,
     pub(crate) columns: Vec<Column<'a>>,
+
+    pub(crate) primary_key: PrimaryKey<'a>,
+    pub(crate) pk_selector_name: String,
 }
 
 impl<'a> OrmModel<'a> {
@@ -59,29 +92,60 @@ impl<'a> OrmModel<'a> {
             ));
         }
 
-        let pk_columns = columns
+        let mut pk_columns = columns
             .iter()
             .filter(|c| c.column_properties.primary_key)
+            .cloned()
             .collect::<Vec<_>>();
-        if pk_columns.len() != 1 {
-            return Err(syn::Error::new(
-                input.ident.span(),
-                "expected exactly one primary key using #[lorm(pk)] attribute",
-            ));
+
+        match top_level_attributes.pk_type {
+            PrimaryKeyType::Generated => {
+                if pk_columns.len() != 1 {
+                    return Err(syn::Error::new(
+                        input.ident.span(),
+                        "expected exactly one primary key when pk_type is Generated",
+                    ));
+                }
+            }
+            PrimaryKeyType::Manual => {
+                if pk_columns.is_empty() {
+                    return Err(syn::Error::new(
+                        input.ident.span(),
+                        "at least one #[lorm(pk)] field required when pk_type is Manual",
+                    ));
+                }
+            }
         }
+
+        let pk_field_names = pk_columns
+            .iter()
+            .map(|c| c.field.to_string())
+            .collect::<Vec<_>>();
+        let pk_field_names_ref = pk_field_names
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>();
+        let pk_selector_name = top_level_attributes.pk_selector_name(&pk_field_names_ref);
+
+        let primary_key = match top_level_attributes.pk_type {
+            PrimaryKeyType::Generated => PrimaryKey::Generated(Box::new(pk_columns.remove(0))),
+            PrimaryKeyType::Manual => PrimaryKey::Manual(pk_columns),
+        };
 
         Ok(Self {
             struct_name,
             struct_visibility,
             table_name,
             columns,
+            primary_key,
+            pk_selector_name,
         })
     }
 
     pub(crate) fn query_columns(&self) -> impl Iterator<Item = &Column<'a>> {
         self.columns
             .iter()
-            .filter(|c| c.should_generate_query_function())
+            .filter(|c| c.should_generate_query_function(self.primary_key.is_generated()))
     }
 
     pub(crate) fn full_column_select(&self) -> String {
@@ -92,11 +156,8 @@ impl<'a> OrmModel<'a> {
             .join(", ")
     }
 
-    pub(crate) fn primary_key(&self) -> &Column<'a> {
-        self.columns
-            .iter()
-            .find(|c| c.column_properties.primary_key)
-            .unwrap()
+    pub(crate) fn primary_key(&self) -> &PrimaryKey<'a> {
+        &self.primary_key
     }
 
     pub(crate) fn created_at(&self) -> Option<&Column<'a>> {
@@ -114,14 +175,18 @@ impl<'a> OrmModel<'a> {
     }
 
     pub(crate) fn insert_columns(&self) -> impl Iterator<Item = &Column<'a>> {
-        let primary_key = self.primary_key();
-        let pk_column = if primary_key.column_properties.readonly {
-            None
-        } else {
-            Some(primary_key)
+        let pk_columns: Box<dyn Iterator<Item = &Column<'a>>> = match &self.primary_key {
+            PrimaryKey::Generated(col) => {
+                if col.column_properties.readonly {
+                    Box::new(std::iter::empty())
+                } else {
+                    Box::new(std::iter::once(col.as_ref()))
+                }
+            }
+            PrimaryKey::Manual(cols) => Box::new(cols.iter()),
         };
 
-        pk_column.into_iter().chain(self.update_columns())
+        pk_columns.chain(self.update_columns())
     }
 }
 

--- a/lorm-macros/src/orm/by.rs
+++ b/lorm-macros/src/orm/by.rs
@@ -14,52 +14,114 @@ pub fn generate_by(
     let struct_visibility = model.struct_visibility;
     let table_name = &model.table_name;
 
-    let stream: Vec<(TokenStream, TokenStream)> = model.query_columns().map(|column| {
-        let field_name = &column.field;
-        let column_name = &column.column_name;
+    let stream: Vec<(TokenStream, TokenStream)> = model
+        .query_columns()
+        .map(|column| {
+            let field_name = &column.field;
+            let column_name = &column.column_name;
 
-        let lifetime = quote! {'a};
-        let parameter = quote! {value};
-        let (param_type, param_value) = get_bind_param_type_and_usage(&parameter, &column.ty, &lifetime).unwrap();
-        let by_fn = format_ident!("by_{}", field_name);
+            let lifetime = quote! {'a};
+            let parameter = quote! {value};
+            let (param_type, param_value) =
+                get_bind_param_type_and_usage(&parameter, &column.ty, &lifetime).unwrap();
+            let by_fn = format_ident!("by_{}", field_name);
 
-        let columns = model.full_column_select();
-        let placeholder = db_placeholder(column.base_field, 1).unwrap();
-        let sql_ident = format!("SELECT {columns} FROM {table_name} WHERE {column_name} = {placeholder}");
+            let columns = model.full_column_select();
+            let placeholder = db_placeholder(column.base_field, 1).unwrap();
+            let sql_ident =
+                format!("SELECT {columns} FROM {table_name} WHERE {column_name} = {placeholder}");
 
-        let field_type_constraints = if column.column_properties.use_json {
-            let base_type = to_column_type(&column.ty).unwrap();
-            quote! { #base_type: serde::Serialize }
-        } else {
-            get_bind_type_where_constraint(&column.ty, database_type, &lifetime).unwrap()
-        };
+            let field_type_constraints = if column.column_properties.use_json {
+                let base_type = to_column_type(&column.ty).unwrap();
+                quote! { #base_type: serde::Serialize }
+            } else {
+                get_bind_type_where_constraint(&column.ty, database_type, &lifetime).unwrap()
+            };
 
-        let bind_value = if column.column_properties.use_json {
-            quote! { sqlx::types::Json(#param_value) }
-        } else {
-            param_value.clone()
-        };
+            let bind_value = if column.column_properties.use_json {
+                quote! { sqlx::types::Json(#param_value) }
+            } else {
+                param_value.clone()
+            };
 
-        let signature = quote! {
-            async fn #by_fn<#lifetime>(executor: E, #parameter: #param_type) -> lorm::errors::Result<#struct_name> where #field_type_constraints
-        };
+            let signature = quote! {
+                async fn #by_fn<#lifetime>(executor: E, #parameter: #param_type) -> lorm::errors::Result<#struct_name> where #field_type_constraints
+            };
 
-        let trait_code = quote! {
-            #signature;
-        };
+            let trait_code = quote! {
+                #signature;
+            };
 
-        let impl_code = quote! {
-            #signature {
-                let r = sqlx::query_as::<_, #struct_name>(#sql_ident)
-                    .bind(#bind_value)
-                    .fetch_one(executor).await?;
-                Ok(r)
-            }
-        };
-        (trait_code, impl_code)
-    }).collect::<Vec<(_, _)>>();
-    let (trait_tokens, impl_tokens): (Vec<TokenStream>, Vec<TokenStream>) =
+            let impl_code = quote! {
+                #signature {
+                    let r = sqlx::query_as::<_, #struct_name>(#sql_ident)
+                        .bind(#bind_value)
+                        .fetch_one(executor).await?;
+                    Ok(r)
+                }
+            };
+            (trait_code, impl_code)
+        })
+        .collect::<Vec<(_, _)>>();
+    let (mut trait_tokens, mut impl_tokens): (Vec<TokenStream>, Vec<TokenStream>) =
         stream.into_iter().unzip();
+
+    // Composite pk selector for Manual primary keys
+    if !model.primary_key.is_generated() {
+        let pk_fields = model.primary_key.fields();
+
+        // Avoid duplicate by_<pk> when user also asked for #[lorm(by)] on the pk field.
+        let would_duplicate_default_single_pk = model.pk_selector_name.starts_with("by_")
+            && pk_fields.len() == 1
+            && pk_fields[0].column_properties.generate_by
+            && model.pk_selector_name == format!("by_{}", pk_fields[0].field);
+
+        if !would_duplicate_default_single_pk {
+            let selector_ident = format_ident!("{}", model.pk_selector_name);
+            let lifetime = quote! {'a};
+
+            let mut where_parts: Vec<String> = Vec::new();
+            let mut param_decls: Vec<TokenStream> = Vec::new();
+            let mut binds: Vec<TokenStream> = Vec::new();
+            let mut constraints: Vec<TokenStream> = Vec::new();
+
+            for (i, col) in pk_fields.iter().enumerate() {
+                let param_ident = &col.field;
+                let param_expr = quote! { #param_ident };
+                let (param_type, param_use) =
+                    get_bind_param_type_and_usage(&param_expr, &col.ty, &lifetime).unwrap();
+                let constraint =
+                    get_bind_type_where_constraint(&col.ty, database_type, &lifetime).unwrap();
+
+                param_decls.push(quote! { #param_ident: #param_type });
+                binds.push(quote! { .bind(#param_use) });
+                constraints.push(constraint);
+
+                let placeholder = db_placeholder(col.base_field, i + 1).unwrap();
+                where_parts.push(format!("{} = {}", col.column_name, placeholder));
+            }
+
+            let where_clause = where_parts.join(" AND ");
+            let columns = model.full_column_select();
+            let sql_ident = format!("SELECT {columns} FROM {table_name} WHERE {where_clause}");
+
+            let signature = quote! {
+                async fn #selector_ident<#lifetime>(executor: E, #(#param_decls),*) -> lorm::errors::Result<#struct_name> where #(#constraints),*
+            };
+
+            trait_tokens.push(quote! {
+                #signature;
+            });
+            impl_tokens.push(quote! {
+                #signature {
+                    let r = sqlx::query_as::<_, #struct_name>(#sql_ident)
+                        #(#binds)*
+                        .fetch_one(executor).await?;
+                    Ok(r)
+                }
+            });
+        }
+    }
 
     Ok(quote! {
         #struct_visibility trait #trait_ident<'e, E: #executor_type>: Sized {

--- a/lorm-macros/src/orm/column.rs
+++ b/lorm-macros/src/orm/column.rs
@@ -35,13 +35,16 @@ impl<'a> Column<'a> {
     /// Whether a `by_*`, `with_*` or selector function should be generated for this column.
     ///
     /// Such a selector should be generated if any of the
-    /// `#[lorm(by)]`, `#[lorm(created_at)]` and `#[lorm(updated_at)]` attributes are present
-    /// or if it is the only field making up the primary key.
-    pub(crate) fn should_generate_query_function(&self) -> bool {
+    /// `#[lorm(by)]`, `#[lorm(created_at)]` and `#[lorm(updated_at)]` attributes are present,
+    /// or if it is part of a generated primary key.
+    ///
+    /// For manual primary keys (including composite), we do not auto-generate `by_<field>` methods
+    /// for the pk fields unless they also have explicit `#[lorm(by)]`.
+    pub(crate) fn should_generate_query_function(&self, pk_is_generated: bool) -> bool {
         self.column_properties.generate_by
             || self.column_properties.created_at
             || self.column_properties.updated_at
-            || self.column_properties.primary_key
+            || (self.column_properties.primary_key && pk_is_generated)
     }
 }
 

--- a/lorm-macros/src/orm/delete.rs
+++ b/lorm-macros/src/orm/delete.rs
@@ -8,15 +8,20 @@ pub fn generate_delete(executor_type: &TokenStream, model: &OrmModel) -> syn::Re
     let struct_visibility = model.struct_visibility;
     let table_name = &model.table_name;
 
-    // Primary key
-    let primary_key = model.primary_key();
-    let pk_value = primary_key.self_accessor();
-    let pk_column = &primary_key.column_name;
-    let pk_placeholder = format!(
-        "{pk_column} = {}",
-        db_placeholder(primary_key.base_field, 1)?
-    );
-    let sql_ident = format!("DELETE FROM {table_name} WHERE {pk_placeholder}");
+    // Primary key(s)
+    let pk_fields = model.primary_key.fields();
+    let mut where_parts = Vec::new();
+    let mut bind_values = Vec::new();
+
+    for (i, pk_col) in pk_fields.iter().enumerate() {
+        let placeholder = db_placeholder(pk_col.base_field, i + 1)?;
+        where_parts.push(format!("{} = {}", pk_col.column_name, placeholder));
+        let accessor = pk_col.self_accessor();
+        bind_values.push(quote! { .bind(#accessor) });
+    }
+
+    let where_clause = where_parts.join(" AND ");
+    let sql_ident = format!("DELETE FROM {table_name} WHERE {where_clause}");
 
     Ok(quote! {
         #struct_visibility trait #trait_ident<'e, E: #executor_type>: Sized {
@@ -27,7 +32,7 @@ pub fn generate_delete(executor_type: &TokenStream, model: &OrmModel) -> syn::Re
         impl<'e, E: #executor_type> #trait_ident<'e, E> for #struct_name {
             async fn delete(&self, executor: E) -> lorm::errors::Result<()> {
                 sqlx::query(#sql_ident)
-                .bind(#pk_value)
+                #(#bind_values)*
                 .execute(executor).await?;
                 Ok(())
             }

--- a/lorm-macros/src/orm/save.rs
+++ b/lorm-macros/src/orm/save.rs
@@ -13,25 +13,72 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
 
     // Primary key
     let primary_key = model.primary_key();
+    let is_manual = !primary_key.is_generated();
     let primary_key_var = quote! {primary_key};
-    let pk_column = &primary_key.column_name;
-    let pk_value = primary_key.self_accessor();
-    let pk_placeholder = format!(
-        "{} = {}",
-        pk_column,
-        db_placeholder(primary_key.base_field, model.update_columns().count() + 1)?
-    );
-    let pk_is_set = &primary_key
-        .column_properties
-        .is_set(quote! { #pk_value }, &primary_key.ty);
-    let pk_code = if primary_key.column_properties.readonly {
-        quote! {}
+
+    // --- pk_is_set and pk_code ---
+    let (pk_is_set, pk_code): (TokenStream, TokenStream) = if is_manual {
+        (quote! { true }, quote! {})
     } else {
-        let pk_new_method = &primary_key.column_properties.new_expression;
-        quote! {
-            let #primary_key_var = #pk_new_method;
-        }
+        let pk_col = primary_key.generated_column();
+        let pk_val = pk_col.self_accessor();
+        let is_set = pk_col
+            .column_properties
+            .is_set(quote! { #pk_val }, &pk_col.ty);
+        let code = if pk_col.column_properties.readonly {
+            quote! {}
+        } else {
+            let new_method = &pk_col.column_properties.new_expression;
+            quote! { let #primary_key_var = #new_method; }
+        };
+        (is_set, code)
     };
+
+    // --- WHERE clause and binds for UPDATE (appended after SET ...) ---
+    let update_col_count = model.update_columns().count();
+    let pk_fields = primary_key.fields();
+    let pk_update_where: String = pk_fields
+        .iter()
+        .enumerate()
+        .map(|(i, col)| {
+            Ok::<_, syn::Error>(format!(
+                "{} = {}",
+                col.column_name,
+                db_placeholder(col.base_field, update_col_count + i + 1)?
+            ))
+        })
+        .collect::<syn::Result<Vec<_>>>()?
+        .join(" AND ");
+
+    // For UPDATE WHERE: always use self_accessor (existing pk values)
+    let pk_update_bind_accessors: Vec<TokenStream> =
+        pk_fields.iter().map(|col| col.self_accessor()).collect();
+
+    // --- WHERE clause for SELECT by pk (MySQL fetch after INSERT/UPDATE) ---
+    let pk_select_where: String = pk_fields
+        .iter()
+        .enumerate()
+        .map(|(i, col)| {
+            Ok::<_, syn::Error>(format!(
+                "{} = {}",
+                col.column_name,
+                db_placeholder(col.base_field, i + 1)?
+            ))
+        })
+        .collect::<syn::Result<Vec<_>>>()?
+        .join(" AND ");
+
+    // For SELECT after INSERT in MySQL manual pk path: use self_accessor
+    // For generated non-readonly pk: bind primary_key_var (the locally generated value)
+    let pk_select_bind_accessors_insert: Vec<TokenStream> = if is_manual {
+        pk_fields.iter().map(|col| col.self_accessor()).collect()
+    } else {
+        vec![quote! { #primary_key_var }]
+    };
+
+    // For SELECT after UPDATE in MySQL: use self_accessor (existing pk values)
+    let pk_select_bind_accessors_update: Vec<TokenStream> =
+        pk_fields.iter().map(|col| col.self_accessor()).collect();
 
     // Created at
     let created_at_var = quote! {created_at};
@@ -65,12 +112,15 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
         }
     };
 
+    // For generated pk: use `primary_key_var` (the locally generated value).
+    // For manual pk: fall through to self_accessor() since pk_code is empty and
+    // there is no local `primary_key` variable.
     let column_value = |column: &Column, use_created_at_var: bool| {
         if column.column_properties.created_at && use_created_at_var {
             created_at_var.clone()
         } else if column.column_properties.updated_at {
             updated_at_var.clone()
-        } else if column.column_properties.primary_key {
+        } else if column.column_properties.primary_key && !is_manual {
             primary_key_var.clone()
         } else {
             let accessor = column.self_accessor();
@@ -107,19 +157,31 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
         "INSERT INTO {table_name} ({insert_columns}) VALUES ({insert_value_placeholders}) RETURNING {full_select_columns}"
     );
     let update_sql_returning = format!(
-        "UPDATE {table_name} SET {update_value_placeholders} WHERE {pk_placeholder} RETURNING {full_select_columns}"
+        "UPDATE {table_name} SET {update_value_placeholders} WHERE {pk_update_where} RETURNING {full_select_columns}"
     );
 
     let insert_sql_no_returning =
         format!("INSERT INTO {table_name} ({insert_columns}) VALUES ({insert_value_placeholders})");
     let update_sql_no_returning =
-        format!("UPDATE {table_name} SET {update_value_placeholders} WHERE {pk_placeholder}");
-    let select_by_pk_sql = format!(
-        "SELECT {full_select_columns} from {table_name} WHERE {pk_column} = {}",
-        db_placeholder(primary_key.base_field, 1)?
-    );
+        format!("UPDATE {table_name} SET {update_value_placeholders} WHERE {pk_update_where}");
+    let select_by_pk_sql =
+        format!("SELECT {full_select_columns} from {table_name} WHERE {pk_select_where}");
 
-    let mysql_insert_fetch = if primary_key.column_properties.readonly {
+    let mysql_insert_fetch = if is_manual {
+        // Manual pk: INSERT then SELECT using all pk field self-accessors
+        quote! {
+            sqlx::query(#insert_sql_no_returning)
+            #(
+                .bind(#insert_values)
+            )*
+            .execute(executor).await?;
+            let r = sqlx::query_as::<_, #struct_name>(#select_by_pk_sql)
+            #(
+                .bind(#pk_select_bind_accessors_insert)
+            )*
+            .fetch_one(executor).await?;
+        }
+    } else if primary_key.generated_column().column_properties.readonly {
         quote! {
             let insert_result = sqlx::query(#insert_sql_no_returning)
             #(
@@ -161,11 +223,15 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
                         #(
                             .bind(#update_values)
                         )*
-                        .bind(#pk_value)
+                        #(
+                            .bind(#pk_update_bind_accessors)
+                        )*
                         .execute(executor).await?;
                         let r = sqlx::query_as::<_, #struct_name>(#select_by_pk_sql)
-                            .bind(#pk_value)
-                            .fetch_one(executor).await?;
+                        #(
+                            .bind(#pk_select_bind_accessors_update)
+                        )*
+                        .fetch_one(executor).await?;
                         Ok(r)
                     }
                 }
@@ -192,7 +258,9 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
                         #(
                             .bind(#update_values)
                         )*
-                        .bind(#pk_value)
+                        #(
+                            .bind(#pk_update_bind_accessors)
+                        )*
                         .fetch_one(executor).await?;
                         Ok(r)
                     }

--- a/lorm/tests/main.rs
+++ b/lorm/tests/main.rs
@@ -130,6 +130,28 @@ mod models {
         pub address: Option<Address>,
     }
 
+    #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+    #[lorm(pk_type = "manual")]
+    pub struct UserRole {
+        #[lorm(pk)]
+        pub user_id: Uuid,
+        #[lorm(pk)]
+        pub role_id: Uuid,
+    }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+    #[lorm(
+        rename = "user_roles_named",
+        pk_type = "manual",
+        pk_selector = "named_by_user_role"
+    )]
+    pub struct UserRoleNamed {
+        #[lorm(pk)]
+        pub user_id: Uuid,
+        #[lorm(pk)]
+        pub role_name: String,
+    }
+
     #[cfg(feature = "sqlite")]
     impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for OptCustomer {
         fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
@@ -308,6 +330,28 @@ mod models {
 
             Ok(Self { id, email, address })
         }
+    }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+    #[lorm(pk_type = "manual")]
+    pub struct UserRole {
+        #[lorm(pk)]
+        pub user_id: Uuid,
+        #[lorm(pk)]
+        pub role_id: Uuid,
+    }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+    #[lorm(
+        rename = "user_roles_named",
+        pk_type = "manual",
+        pk_selector = "named_by_user_role"
+    )]
+    pub struct UserRoleNamed {
+        #[lorm(pk)]
+        pub user_id: Uuid,
+        #[lorm(pk)]
+        pub role_name: String,
     }
 }
 
@@ -812,4 +856,76 @@ async fn test_opt_customer_with_none_address() {
 
     let fetched = OptCustomer::by_email(&pool, &c.email).await.unwrap();
     assert!(fetched.address.is_none());
+}
+
+#[tokio::test]
+async fn test_user_role_save_inserts() {
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let r = UserRole {
+        user_id: Uuid::new_v4(),
+        role_id: Uuid::new_v4(),
+    };
+    r.save(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_user_role_by_key_returns_match() {
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let r = UserRole {
+        user_id: Uuid::new_v4(),
+        role_id: Uuid::new_v4(),
+    };
+    r.save(&pool).await.unwrap();
+
+    let fetched = UserRole::by_key(&pool, &r.user_id, &r.role_id)
+        .await
+        .unwrap();
+    assert_eq!(fetched.user_id, r.user_id);
+    assert_eq!(fetched.role_id, r.role_id);
+}
+
+#[tokio::test]
+async fn test_user_role_named_by_user_role() {
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let r = UserRoleNamed {
+        user_id: Uuid::new_v4(),
+        role_name: "admin".to_string(),
+    };
+    r.save(&pool).await.unwrap();
+
+    let fetched = UserRoleNamed::named_by_user_role(&pool, &r.user_id, &r.role_name)
+        .await
+        .unwrap();
+    assert_eq!(fetched.user_id, r.user_id);
+    assert_eq!(fetched.role_name, r.role_name);
+}
+
+#[tokio::test]
+async fn test_user_role_delete_composite() {
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let r = UserRole {
+        user_id: Uuid::new_v4(),
+        role_id: Uuid::new_v4(),
+    };
+    r.save(&pool).await.unwrap();
+    r.delete(&pool).await.unwrap();
+
+    let res = UserRole::by_key(&pool, &r.user_id, &r.role_id).await;
+    assert_eq!(res.is_err(), true);
+}
+
+#[tokio::test]
+async fn test_backcompat_generated_pk_by_id_still_works() {
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let mut u = User::default();
+    u.email = SafeEmail().fake::<String>();
+    let u = u.save(&pool).await.unwrap();
+
+    let fetched = User::by_id(&pool, &u.id).await.unwrap();
+    assert_eq!(fetched.id, u.id);
 }

--- a/lorm/tests/resources/migrations/mysql/07_user_roles_table.sql
+++ b/lorm/tests/resources/migrations/mysql/07_user_roles_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id BINARY(16) NOT NULL,
+    role_id BINARY(16) NOT NULL,
+    PRIMARY KEY (user_id, role_id)
+);

--- a/lorm/tests/resources/migrations/mysql/08_user_roles_named_table.sql
+++ b/lorm/tests/resources/migrations/mysql/08_user_roles_named_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS user_roles_named (
     user_id BINARY(16) NOT NULL,
-    role_name TEXT NOT NULL,
+    role_name VARCHAR(255) NOT NULL,
     PRIMARY KEY (user_id, role_name)
 );

--- a/lorm/tests/resources/migrations/mysql/08_user_roles_named_table.sql
+++ b/lorm/tests/resources/migrations/mysql/08_user_roles_named_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS user_roles_named (
+    user_id BINARY(16) NOT NULL,
+    role_name TEXT NOT NULL,
+    PRIMARY KEY (user_id, role_name)
+);

--- a/lorm/tests/resources/migrations/postgres/07_user_roles_table.sql
+++ b/lorm/tests/resources/migrations/postgres/07_user_roles_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id UUID NOT NULL,
+    role_id UUID NOT NULL,
+    PRIMARY KEY (user_id, role_id)
+);

--- a/lorm/tests/resources/migrations/postgres/08_user_roles_named_table.sql
+++ b/lorm/tests/resources/migrations/postgres/08_user_roles_named_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS user_roles_named (
+    user_id UUID NOT NULL,
+    role_name TEXT NOT NULL,
+    PRIMARY KEY (user_id, role_name)
+);

--- a/lorm/tests/resources/migrations/sqlite/07_user_roles_table.sql
+++ b/lorm/tests/resources/migrations/sqlite/07_user_roles_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id BLOB NOT NULL,
+    role_id BLOB NOT NULL,
+    PRIMARY KEY (user_id, role_id)
+);

--- a/lorm/tests/resources/migrations/sqlite/08_user_roles_named_table.sql
+++ b/lorm/tests/resources/migrations/sqlite/08_user_roles_named_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS user_roles_named (
+    user_id BLOB NOT NULL,
+    role_name TEXT NOT NULL,
+    PRIMARY KEY (user_id, role_name)
+);


### PR DESCRIPTION
## Summary

- Add `#[lorm(pk_type = "manual")]` struct attribute for composite/manual primary keys
- Mark each pk column with `#[lorm(pk)]`; all pk fields together form the composite key
- Generates `save()`, `delete()`, and a composite selector (`by_key()` or custom name via `pk_selector`)
- Generated pk (default behavior) is fully backward-compatible

## Changes

**`lorm-macros`**
- `attributes.rs`: `PrimaryKeyType` enum, `pk_type`/`pk_selector` struct attributes, `pk_selector_name()` helper
- `models.rs`: `PrimaryKey<'a>` enum (`Generated`/`Manual`), `OrmModel.primary_key: PrimaryKey`, composite-aware `insert_columns()` and `query_columns()`
- `column.rs`: `should_generate_query_function(pk_is_generated: bool)` — skips auto `by_<field>` for manual pk fields unless explicitly `#[lorm(by)]`
- `delete.rs`: AND-joined WHERE across all pk fields
- `save.rs`: `pk_is_set=true` always for Manual pk (always INSERT); INSERT binds use `self_accessor()` for pk fields; UPDATE WHERE uses all pk field accessors
- `by.rs`: `by_key()` (or custom name) composite selector generated for Manual pk

**Tests**
- `UserRole` (composite pk: `user_id + role_id`) and `UserRoleNamed` (custom selector `named_by_user_role`)
- Migration files `07_user_roles_table.sql` and `08_user_roles_named_table.sql` for sqlite, postgres, mysql

## Testing

All 23 tests pass with `--features=sqlite`. No existing tests broken.