### PR TITLE
feat(macros): conditional upsert for manual pk save()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `save()` now performs upsert (`INSERT ... ON CONFLICT DO UPDATE` / `ON DUPLICATE KEY UPDATE`) for `pk_type = "manual"` models. Full-key models (all columns are primary key) use `DO NOTHING` / `INSERT IGNORE` with a fallback `SELECT` to return the existing row.
 - Support composite primary keys via `#[lorm(pk_type = "manual")]` on the struct. Mark each pk field with `#[lorm(pk)]`. A `by_key()` selector method is generated automatically (or a custom name via `#[lorm(pk_selector = "my_fn")]`).
 - Support `#[sqlx(json)]` attribute on fields. Lorm wraps bind values with `sqlx::types::Json` automatically. The bare `#[sqlx(json)]` form is supported; `#[sqlx(json(nullable))]` is not supported in this release. A field with `#[sqlx(json)]` cannot be the primary key.
 - Support flattened nested structs via `#[sqlx(flatten)]` used together with `#[lorm(flattened(field: Type, field2: Type = "renamed_col"))]`.

--- a/README.md
+++ b/README.md
@@ -441,6 +441,11 @@ saved.delete(&pool).await?;
 
 For a custom selector name, use `#[lorm(pk_type = "manual", pk_selector = "find_by_ids")]`.
 
+When `save()` is called on a `pk_type = "manual"` model, it performs an **upsert** rather than a conditional INSERT/UPDATE:
+- **PostgreSQL / SQLite**: `INSERT ... ON CONFLICT (pk_cols) DO UPDATE SET non_pk = EXCLUDED.non_pk ... RETURNING *`
+- **MySQL**: `INSERT ... ON DUPLICATE KEY UPDATE non_pk = VALUES(non_pk), ...` followed by `SELECT`
+- **Full-key models** (all columns are primary key): uses `ON CONFLICT DO NOTHING` / `INSERT IGNORE` with a fallback SELECT to return the existing row.
+
 ### Can I customize the SQL queries Lorm generates?
 
 No. Lorm generates standard CRUD operations. For custom queries, use SQLx alongside Lorm.

--- a/lorm-macros/src/orm/save.rs
+++ b/lorm-macros/src/orm/save.rs
@@ -36,6 +36,7 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
 
     // --- WHERE clause and binds for UPDATE (appended after SET ...) ---
     let update_col_count = model.update_columns().count();
+    let is_full_key = update_col_count == 0;
     let pk_fields = primary_key.fields();
     let pk_update_where: String = pk_fields
         .iter()
@@ -206,7 +207,109 @@ pub fn generate_save(executor_type: &TokenStream, model: &OrmModel) -> syn::Resu
         }
     };
 
-    let (executor_bound, save_body) = if cfg!(feature = "mysql") {
+    let pk_col_names: Vec<&str> = pk_fields.iter().map(|c| c.column_name.as_str()).collect();
+    let pk_cols_list = pk_col_names.join(", ");
+
+    let excluded_updates: String = model
+        .update_columns()
+        .map(|col| format!("{0} = EXCLUDED.{0}", col.column_name))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let mysql_updates: String = model
+        .update_columns()
+        .map(|col| format!("{0} = VALUES({0})", col.column_name))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let (executor_bound, save_body) = if is_manual {
+        if cfg!(feature = "mysql") {
+            let (upsert_sql, select_sql) = if is_full_key {
+                (
+                    format!(
+                        "INSERT IGNORE INTO {table_name} ({insert_columns}) VALUES ({insert_value_placeholders})"
+                    ),
+                    format!(
+                        "SELECT {full_select_columns} from {table_name} WHERE {pk_select_where}"
+                    ),
+                )
+            } else {
+                (
+                    format!(
+                        "INSERT INTO {table_name} ({insert_columns}) VALUES ({insert_value_placeholders}) ON DUPLICATE KEY UPDATE {mysql_updates}"
+                    ),
+                    format!(
+                        "SELECT {full_select_columns} from {table_name} WHERE {pk_select_where}"
+                    ),
+                )
+            };
+
+            let mysql_upsert_fetch = quote! {
+                sqlx::query(#upsert_sql)
+                #(
+                    .bind(#insert_values)
+                )*
+                .execute(executor).await?;
+                let r = sqlx::query_as::<_, #struct_name>(#select_sql)
+                #(
+                    .bind(#pk_select_bind_accessors_insert)
+                )*
+                .fetch_one(executor).await?;
+            };
+
+            (
+                quote! { E: #executor_type + Copy },
+                quote! {
+                    #updated_at_code
+                    #mysql_upsert_fetch
+                    Ok(r)
+                },
+            )
+        } else if is_full_key {
+            let upsert_sql_do_nothing = format!(
+                "INSERT INTO {table_name} ({insert_columns}) VALUES ({insert_value_placeholders}) ON CONFLICT ({pk_cols_list}) DO NOTHING RETURNING {full_select_columns}"
+            );
+            let select_by_pk_sql_val =
+                format!("SELECT {full_select_columns} from {table_name} WHERE {pk_select_where}");
+            (
+                quote! { E: #executor_type + Copy },
+                quote! {
+                    #updated_at_code
+                    let r_opt = sqlx::query_as::<_, #struct_name>(#upsert_sql_do_nothing)
+                    #(
+                        .bind(#insert_values)
+                    )*
+                    .fetch_optional(executor).await?;
+                    let r = if let Some(row) = r_opt {
+                        row
+                    } else {
+                        sqlx::query_as::<_, #struct_name>(#select_by_pk_sql_val)
+                        #(
+                            .bind(#pk_select_bind_accessors_insert)
+                        )*
+                        .fetch_one(executor).await?
+                    };
+                    Ok(r)
+                },
+            )
+        } else {
+            let upsert_sql_do_update = format!(
+                "INSERT INTO {table_name} ({insert_columns}) VALUES ({insert_value_placeholders}) ON CONFLICT ({pk_cols_list}) DO UPDATE SET {excluded_updates} RETURNING {full_select_columns}"
+            );
+            (
+                quote! { E: #executor_type },
+                quote! {
+                    #updated_at_code
+                    let r = sqlx::query_as::<_, #struct_name>(#upsert_sql_do_update)
+                    #(
+                        .bind(#insert_values)
+                    )*
+                    .fetch_one(executor).await?;
+                    Ok(r)
+                },
+            )
+        }
+    } else if cfg!(feature = "mysql") {
         (
             quote! { E: #executor_type + Copy },
             quote! {

--- a/lorm/tests/main.rs
+++ b/lorm/tests/main.rs
@@ -134,9 +134,10 @@ mod models {
     #[lorm(pk_type = "manual")]
     pub struct UserRole {
         #[lorm(pk)]
-        pub user_id: Uuid,
+        pub user_id: String,
         #[lorm(pk)]
-        pub role_id: Uuid,
+        pub role_id: String,
+        pub assigned_at: String,
     }
 
     #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
@@ -150,6 +151,13 @@ mod models {
         pub user_id: Uuid,
         #[lorm(pk)]
         pub role_name: String,
+    }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+    #[lorm(pk_type = "manual")]
+    pub struct Tag {
+        #[lorm(pk)]
+        pub name: String,
     }
 
     #[cfg(feature = "sqlite")]
@@ -336,9 +344,10 @@ mod models {
     #[lorm(pk_type = "manual")]
     pub struct UserRole {
         #[lorm(pk)]
-        pub user_id: Uuid,
+        pub user_id: String,
         #[lorm(pk)]
-        pub role_id: Uuid,
+        pub role_id: String,
+        pub assigned_at: String,
     }
 
     #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
@@ -352,6 +361,13 @@ mod models {
         pub user_id: Uuid,
         #[lorm(pk)]
         pub role_name: String,
+    }
+
+    #[derive(Debug, Default, Clone, sqlx::FromRow, lorm::ToLOrm)]
+    #[lorm(pk_type = "manual")]
+    pub struct Tag {
+        #[lorm(pk)]
+        pub name: String,
     }
 }
 
@@ -863,8 +879,9 @@ async fn test_user_role_save_inserts() {
     let pool = get_pool().await.expect("Failed to create pool");
 
     let r = UserRole {
-        user_id: Uuid::new_v4(),
-        role_id: Uuid::new_v4(),
+        user_id: Uuid::new_v4().to_string(),
+        role_id: Uuid::new_v4().to_string(),
+        ..Default::default()
     };
     r.save(&pool).await.unwrap();
 }
@@ -874,8 +891,9 @@ async fn test_user_role_by_key_returns_match() {
     let pool = get_pool().await.expect("Failed to create pool");
 
     let r = UserRole {
-        user_id: Uuid::new_v4(),
-        role_id: Uuid::new_v4(),
+        user_id: Uuid::new_v4().to_string(),
+        role_id: Uuid::new_v4().to_string(),
+        ..Default::default()
     };
     r.save(&pool).await.unwrap();
 
@@ -908,14 +926,189 @@ async fn test_user_role_delete_composite() {
     let pool = get_pool().await.expect("Failed to create pool");
 
     let r = UserRole {
-        user_id: Uuid::new_v4(),
-        role_id: Uuid::new_v4(),
+        user_id: Uuid::new_v4().to_string(),
+        role_id: Uuid::new_v4().to_string(),
+        ..Default::default()
     };
     r.save(&pool).await.unwrap();
     r.delete(&pool).await.unwrap();
 
     let res = UserRole::by_key(&pool, &r.user_id, &r.role_id).await;
     assert_eq!(res.is_err(), true);
+}
+
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+#[tokio::test]
+async fn test_user_role_save_updates() {
+    use models::*;
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let ur = UserRole {
+        user_id: "user_upd".to_string(),
+        role_id: "editor".to_string(),
+        assigned_at: "2024-01-01".to_string(),
+    };
+    let saved = ur.save(&pool).await.unwrap();
+    assert_eq!(saved.assigned_at, "2024-01-01");
+
+    let ur2 = UserRole {
+        user_id: "user_upd".to_string(),
+        role_id: "editor".to_string(),
+        assigned_at: "2024-06-15".to_string(),
+    };
+    let upserted = ur2.save(&pool).await.unwrap();
+    assert_eq!(upserted.assigned_at, "2024-06-15");
+
+    let count_result = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM user_roles WHERE user_id = 'user_upd' AND role_id = 'editor'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count_result, 1);
+
+    upserted.delete(&pool).await.unwrap();
+}
+
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+#[tokio::test]
+async fn test_user_role_save_idempotent() {
+    use models::*;
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let ur = UserRole {
+        user_id: "user_idem".to_string(),
+        role_id: "viewer".to_string(),
+        assigned_at: "2024-03-01".to_string(),
+    };
+    let saved1 = ur.save(&pool).await.unwrap();
+    let saved2 = ur.save(&pool).await.unwrap();
+    assert_eq!(saved1.assigned_at, saved2.assigned_at);
+
+    let count_result = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM user_roles WHERE user_id = 'user_idem' AND role_id = 'viewer'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count_result, 1);
+
+    saved2.delete(&pool).await.unwrap();
+}
+
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+#[tokio::test]
+async fn test_tag_full_key_upsert_idempotent() {
+    use models::*;
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let tag = Tag {
+        name: "rust".to_string(),
+    };
+    let saved1 = tag.save(&pool).await.unwrap();
+    assert_eq!(saved1.name, "rust");
+
+    let saved2 = tag.save(&pool).await.unwrap();
+    assert_eq!(saved2.name, "rust");
+
+    let count_result =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM tags WHERE name = 'rust'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count_result, 1);
+
+    sqlx::query("DELETE FROM tags WHERE name = 'rust'")
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test]
+async fn test_user_role_save_updates_mysql() {
+    use models::*;
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let ur = UserRole {
+        user_id: "user_upd".to_string(),
+        role_id: "editor".to_string(),
+        assigned_at: "2024-01-01".to_string(),
+    };
+    let saved = ur.save(&pool).await.unwrap();
+    assert_eq!(saved.assigned_at, "2024-01-01");
+
+    let ur2 = UserRole {
+        user_id: "user_upd".to_string(),
+        role_id: "editor".to_string(),
+        assigned_at: "2024-06-15".to_string(),
+    };
+    let upserted = ur2.save(&pool).await.unwrap();
+    assert_eq!(upserted.assigned_at, "2024-06-15");
+
+    let count_result = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM user_roles WHERE user_id = 'user_upd' AND role_id = 'editor'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count_result, 1);
+
+    upserted.delete(&pool).await.unwrap();
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test]
+async fn test_user_role_save_idempotent_mysql() {
+    use models::*;
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let ur = UserRole {
+        user_id: "user_idem".to_string(),
+        role_id: "viewer".to_string(),
+        assigned_at: "2024-03-01".to_string(),
+    };
+    let saved1 = ur.save(&pool).await.unwrap();
+    let saved2 = ur.save(&pool).await.unwrap();
+    assert_eq!(saved1.assigned_at, saved2.assigned_at);
+
+    let count_result = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM user_roles WHERE user_id = 'user_idem' AND role_id = 'viewer'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count_result, 1);
+
+    saved2.delete(&pool).await.unwrap();
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test]
+async fn test_tag_full_key_upsert_idempotent_mysql() {
+    use models::*;
+    let pool = get_pool().await.expect("Failed to create pool");
+
+    let tag = Tag {
+        name: "rust".to_string(),
+    };
+    let saved1 = tag.save(&pool).await.unwrap();
+    assert_eq!(saved1.name, "rust");
+
+    let saved2 = tag.save(&pool).await.unwrap();
+    assert_eq!(saved2.name, "rust");
+
+    let count_result =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM tags WHERE name = 'rust'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count_result, 1);
+
+    sqlx::query("DELETE FROM tags WHERE name = 'rust'")
+        .execute(&pool)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/lorm/tests/resources/migrations/mysql/07_user_roles_table.sql
+++ b/lorm/tests/resources/migrations/mysql/07_user_roles_table.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS user_roles (
-    user_id BINARY(16) NOT NULL,
-    role_id BINARY(16) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    role_id VARCHAR(255) NOT NULL,
+    assigned_at TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (user_id, role_id)
 );

--- a/lorm/tests/resources/migrations/mysql/07_user_roles_table.sql
+++ b/lorm/tests/resources/migrations/mysql/07_user_roles_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS user_roles (
     user_id VARCHAR(255) NOT NULL,
     role_id VARCHAR(255) NOT NULL,
-    assigned_at TEXT NOT NULL DEFAULT '',
+    assigned_at VARCHAR(255) NOT NULL DEFAULT '',
     PRIMARY KEY (user_id, role_id)
 );

--- a/lorm/tests/resources/migrations/mysql/09_tags_table.sql
+++ b/lorm/tests/resources/migrations/mysql/09_tags_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS tags (
+    name TEXT NOT NULL,
+    PRIMARY KEY (name(255))
+);

--- a/lorm/tests/resources/migrations/postgres/07_user_roles_table.sql
+++ b/lorm/tests/resources/migrations/postgres/07_user_roles_table.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS user_roles (
-    user_id UUID NOT NULL,
-    role_id UUID NOT NULL,
+    user_id TEXT NOT NULL,
+    role_id TEXT NOT NULL,
+    assigned_at TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (user_id, role_id)
 );

--- a/lorm/tests/resources/migrations/postgres/09_tags_table.sql
+++ b/lorm/tests/resources/migrations/postgres/09_tags_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS tags (
+    name TEXT NOT NULL,
+    PRIMARY KEY (name)
+);

--- a/lorm/tests/resources/migrations/sqlite/07_user_roles_table.sql
+++ b/lorm/tests/resources/migrations/sqlite/07_user_roles_table.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS user_roles (
-    user_id BLOB NOT NULL,
-    role_id BLOB NOT NULL,
+    user_id TEXT NOT NULL,
+    role_id TEXT NOT NULL,
+    assigned_at TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (user_id, role_id)
 );

--- a/lorm/tests/resources/migrations/sqlite/09_tags_table.sql
+++ b/lorm/tests/resources/migrations/sqlite/09_tags_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS tags (
+    name TEXT NOT NULL,
+    PRIMARY KEY (name)
+);


### PR DESCRIPTION
## Summary

- `save()` on `pk_type = \"manual\"` models now performs an **upsert** instead of a plain INSERT:
  - **PostgreSQL / SQLite**: `INSERT ... ON CONFLICT (pk_cols) DO UPDATE SET non_pk = EXCLUDED.non_pk ... RETURNING *`
  - **MySQL**: `INSERT ... ON DUPLICATE KEY UPDATE non_pk = VALUES(non_pk), ...` + `SELECT`
  - **Full-key models** (all columns are pk): `ON CONFLICT DO NOTHING RETURNING *` with fallback SELECT / `INSERT IGNORE` + SELECT
- Generated pk models (`User`, `AltUser`, etc.) save behavior is **unchanged**
- Adds `Tag` model (single-col pk, full-key test), `assigned_at` field on `UserRole`, migration `09_tags_table`
- 26 SQLite tests all pass including 3 new upsert tests

## Changes

- `lorm-macros/src/orm/save.rs`: outer branch on `is_manual` before feature check; upsert SQL for all three backends
- `lorm/tests/main.rs`: `Tag` + updated `UserRole` models; new upsert tests
- Migrations: `07_user_roles_table.sql` updated to TEXT types + `assigned_at`; `09_tags_table.sql` added for all backends
- `README.md`, `CHANGELOG.md`: upsert behavior documented