### PR TITLE
ci: fix release workflow - add --no-verify to lorm package step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Package crates for attestation
         run: |
           cargo package -p lorm-macros --target-dir attestation-artifacts
-          cargo package -p lorm --target-dir attestation-artifacts
+          cargo package -p lorm --no-verify --target-dir attestation-artifacts
 
           mkdir -p attestation-output
           find attestation-artifacts/package -name '*.crate' -exec cp {} attestation-output/ \;


### PR DESCRIPTION
## Problem

The Release workflow (triggered on `v0.3.0` tag) failed at the \"Package crates for attestation\" step with:

\`\`\`
error: failed to prepare local package for uploading
  failed to select a version for the requirement \`lorm-macros = \"^0.3.0\"\`
\`\`\`

When \`cargo package -p lorm\` runs, Cargo strips path dependencies and resolves them from the registry. Since \`lorm-macros 0.3.0\` hasn't been published to crates.io, the resolution fails.

## Fix

Add \`--no-verify\` to the \`lorm\` package step. This skips the per-package build verification (which duplicates the \"Build workspace\" step that already ran successfully). The crate is still packaged correctly for attestation.

\`lorm-macros\` doesn't need \`--no-verify\` since it has no path dependencies.