### PR TITLE
ci: fix release attestation - patch crates-io to package lorm before publishing lorm-macros

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,16 @@ jobs:
 
       - name: Package crates for attestation
         run: |
+          # lorm-macros has no unpublished path deps — package normally
           cargo package -p lorm-macros --target-dir attestation-artifacts
+
+          # lorm depends on lorm-macros which is not yet on crates.io.
+          # Patch crates-io to use the local workspace copy so cargo can resolve
+          # the dependency when generating the packaged manifest, then package
+          # without re-verifying the build (already done in the prior step).
+          printf '\n[patch.crates-io]\nlorm-macros = { path = "lorm-macros" }\n' >> Cargo.toml
           cargo package -p lorm --no-verify --target-dir attestation-artifacts
+          git checkout Cargo.toml
 
           mkdir -p attestation-output
           find attestation-artifacts/package -name '*.crate' -exec cp {} attestation-output/ \;


### PR DESCRIPTION
## Problem

The Release workflow fails at \"Package crates for attestation\" with:

\`\`\`
error: failed to prepare local package for uploading
  failed to select a version for the requirement \`lorm-macros = \"^0.3.0\"\`
\`\`\`

When \`cargo package -p lorm\` runs, it rewrites the path dependency \`lorm-macros = { path = \"...\", version = \"0.3.0\" }\` to a registry dependency \`lorm-macros = \"0.3.0\"\` in the generated manifest. Cargo then tries to resolve this from crates.io and fails because \`lorm-macros 0.3.0\` hasn't been published yet.

\`--no-verify\` (added in PR #20) skips the compilation step but not the dependency resolution check.

## Fix

Add a temporary \`[patch.crates-io]\` entry to the workspace \`Cargo.toml\` before packaging \`lorm\`. This tells Cargo to use the local \`lorm-macros\` workspace member when resolving the crates.io dependency, allowing \`cargo package -p lorm --no-verify\` to succeed. The patch is reverted via \`git checkout Cargo.toml\` immediately after.