### PR TITLE
feat(release): version lifecycle with -dev suffix and auto-derived bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,20 @@ jobs:
       - run: rustup toolchain install
       - uses: Swatinem/rust-cache@v2
 
+      - name: Verify release version has no pre-release suffix
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          TAG="${GITHUB_REF#refs/tags/v}"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "ERROR: Cargo.toml version '$VERSION' contains a pre-release suffix."
+            echo "Run './bump-version.sh --release' to strip it before tagging."
+            exit 1
+          fi
+          if [[ "$VERSION" != "$TAG" ]]; then
+            echo "ERROR: Cargo.toml version '$VERSION' does not match tag '$TAG'."
+            exit 1
+          fi
+
       - name: Build workspace
         run: cargo build --release --workspace
 

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -8,152 +8,259 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Function to display help
 show_help() {
-    cat << EOF
-Usage: $0 [OPTION]
+    cat << 'EOF'
+Usage: ./bump-version.sh COMMAND [OPTIONS]
 
-Bump the project version and update the CHANGELOG using git-cliff.
+Manage project version following the X.Y.Z-dev → X.Y.Z release cycle.
 
-Options:
-    --revision    Bump the revision/patch version (0.0.X)
-    --minor       Bump the minor version (0.X.0)
-    --major       Bump the major version (X.0.0)
-    --help        Display this help message
+COMMANDS
 
-Examples:
-    $0 --revision    # 0.0.9 -> 0.0.10
-    $0 --minor       # 0.0.9 -> 0.1.0
-    $0 --major       # 0.0.9 -> 1.0.0
+  --post-release
+        Add -dev suffix to the current version immediately after a release.
+        Does NOT bump the version number — the suffix signals "unreleased work
+        on top of X.Y.Z". No CHANGELOG change.
 
-Note: This script will:
-  1. Update the version in Cargo.toml (workspace)
-  2. Generate/update CHANGELOG.md using git-cliff
-  3. Stage both files for commit (you need to commit manually)
+        Example: 0.3.0  →  0.3.0-dev
 
-Requirements:
-  - git-cliff must be installed (cargo install git-cliff)
+  --release [--minor | --major | --revision]
+        Prepare a release commit. Strips -dev, derives the next version from
+        conventional commits via git-cliff --bump, and finalises CHANGELOG.
+        Pass an explicit bump flag to override the auto-derived type.
 
+        Examples:
+          ./bump-version.sh --release              # auto-derived from commits
+          ./bump-version.sh --release --minor      # force minor bump
+          ./bump-version.sh --release --major      # force major bump
+          ./bump-version.sh --release --revision   # force patch bump
+
+        Input → output (auto-derived):
+          0.3.0-dev + only fix: commits  →  0.3.1
+          0.3.0-dev + feat: commit       →  0.4.0
+          0.3.0-dev + feat!: commit      →  1.0.0
+
+  --revision
+        Mid-cycle patch re-plan. Keeps -dev suffix.
+        Example: 0.3.0-dev  →  0.3.1-dev
+
+  --minor
+        Mid-cycle minor re-plan. Keeps -dev suffix.
+        Example: 0.3.0-dev  →  0.4.0-dev
+
+  --major
+        Mid-cycle major re-plan. Keeps -dev suffix.
+        Example: 0.3.0-dev  →  1.0.0-dev
+
+  --help
+        Show this message.
+
+TYPICAL LIFECYCLE
+
+  # Immediately after releasing v0.3.0:
+  ./bump-version.sh --post-release
+  git commit -m 'chore: begin development on next release'
+  git push
+
+  # (All feature work lands on main; version stays 0.3.0-dev throughout)
+
+  # Ready to ship:
+  ./bump-version.sh --release           # or: --release --minor to override
+  git commit -m 'chore(release): prepare for vX.Y.Z'
+  # open PR → merge to main → tag → push tag
+
+REQUIREMENTS
+  git-cliff must be installed: cargo install git-cliff
 EOF
 }
 
-# Function to print colored messages
-print_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
-}
+print_info()    { echo -e "${GREEN}[INFO]${NC} $1"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
 
-print_error() {
-    echo -e "${RED}[ERROR]${NC} $1" >&2
-}
-
-print_warning() {
-    echo -e "${YELLOW}[WARNING]${NC} $1"
-}
-
-# Check if git-cliff is installed
 check_dependencies() {
-    if ! command -v git-cliff &> /dev/null; then
+    if ! command -v git-cliff &>/dev/null; then
         print_error "git-cliff is not installed."
-        echo "Please install it with: cargo install git-cliff"
+        echo "Install with: cargo install git-cliff"
         exit 1
     fi
 }
 
-# Get current version from Cargo.toml
-get_current_version() {
+get_raw_version() {
     grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/'
 }
 
-# Parse version components
+get_base_version() {
+    get_raw_version | sed 's/-dev$//'
+}
+
 parse_version() {
-    local version=$1
-    echo "$version" | sed 's/\./ /g'
+    echo "$1" | sed 's/\./ /g'
 }
 
-# Bump version based on type
-bump_version() {
-    local current_version=$1
-    local bump_type=$2
-
-    read -r major minor patch <<< "$(parse_version "$current_version")"
-
-    case $bump_type in
-        major)
-            major=$((major + 1))
-            minor=0
-            patch=0
-            ;;
-        minor)
-            minor=$((minor + 1))
-            patch=0
-            ;;
-        revision)
-            patch=$((patch + 1))
-            ;;
-        *)
-            print_error "Unknown bump type: $bump_type"
-            exit 1
-            ;;
+apply_bump() {
+    local base="$1" type="$2"
+    read -r major minor patch <<< "$(parse_version "$base")"
+    case "$type" in
+        major)    echo "$((major + 1)).0.0" ;;
+        minor)    echo "$major.$((minor + 1)).0" ;;
+        revision) echo "$major.$minor.$((patch + 1))" ;;
+        *) print_error "Unknown bump type: $type"; exit 1 ;;
     esac
-
-    echo "$major.$minor.$patch"
 }
 
-# Update version in Cargo.toml
 update_cargo_version() {
-    local new_version=$1
-    local cargo_file="Cargo.toml"
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        # macOS
-        sed -i '' "s/^version = \".*\"/version = \"$new_version\"/" "$cargo_file"
+    local ver="$1"
+    if [[ "$OSTYPE" == darwin* ]]; then
+        sed -i '' "s/^version = \".*\"/version = \"$ver\"/" Cargo.toml
     else
-        # Linux
-        sed -i "s/^version = \".*\"/version = \"$new_version\"/" "$cargo_file"
+        sed -i "s/^version = \".*\"/version = \"$ver\"/" Cargo.toml
     fi
-
-    print_info "Updated $cargo_file to version $new_version"
+    # Regenerate Cargo.lock to keep it consistent with the new version.
+    cargo metadata --format-version 1 --no-deps > /dev/null 2>&1 || true
+    print_info "Cargo.toml → version = \"$ver\""
 }
 
-# Generate changelog using git-cliff
 update_changelog() {
-    local new_version=$1
-
-    print_info "Generating CHANGELOG.md using git-cliff..."
-
-    if git-cliff --unreleased --tag "v$new_version" -o CHANGELOG.md; then
-        print_info "CHANGELOG.md updated successfully"
+    local tag="$1"
+    print_info "Generating CHANGELOG.md for $tag …"
+    if git-cliff --unreleased --tag "$tag" -o CHANGELOG.md; then
+        print_info "CHANGELOG.md updated."
     else
         print_error "Failed to generate CHANGELOG.md"
         exit 1
     fi
 }
 
-# Main script
+confirm() {
+    read -rp "$1 (y/N) " -n 1
+    echo
+    [[ "$REPLY" =~ ^[Yy]$ ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Command implementations
+# ─────────────────────────────────────────────────────────────────────────────
+
+cmd_post_release() {
+    local raw; raw=$(get_raw_version)
+
+    if [[ "$raw" == *-dev ]]; then
+        print_warning "Version is already a dev version: $raw"
+        exit 0
+    fi
+
+    local new_ver="${raw}-dev"
+    confirm "Add -dev suffix: $raw → $new_ver?" \
+        || { print_warning "Cancelled."; exit 0; }
+
+    update_cargo_version "$new_ver"
+    git add Cargo.toml Cargo.lock
+
+    print_info ""
+    print_info "Done. Next step:"
+    print_info "  git commit -m 'chore: begin development on next release'"
+}
+
+cmd_dev_bump() {
+    local type="$1"
+    local raw; raw=$(get_raw_version)
+    local base; base=$(get_base_version)
+    local new_ver; new_ver="$(apply_bump "$base" "$type")-dev"
+
+    confirm "Mid-cycle re-plan: $raw → $new_ver?" \
+        || { print_warning "Cancelled."; exit 0; }
+
+    update_cargo_version "$new_ver"
+    git add Cargo.toml Cargo.lock
+
+    print_info ""
+    print_info "Done. Next step:"
+    print_info "  git commit -m 'chore: re-plan next release as $new_ver'"
+}
+
+cmd_release() {
+    local bump_override="$1"
+
+    check_dependencies
+
+    local raw; raw=$(get_raw_version)
+    local base; base=$(get_base_version)
+
+    if [[ "$raw" != *-dev ]]; then
+        print_warning "Current version '$raw' has no -dev suffix."
+        confirm "Proceed anyway?" || { print_warning "Cancelled."; exit 0; }
+    fi
+
+    local new_ver
+    if [[ -n "$bump_override" ]]; then
+        new_ver=$(apply_bump "$base" "$bump_override")
+        print_info "Using explicit bump ($bump_override): $base → $new_ver"
+    else
+        local cliff_out
+        cliff_out=$(git-cliff --bumped-version 2>/dev/null || true)
+        new_ver="${cliff_out#v}"                  # strip leading 'v' if present
+        new_ver="${new_ver//[[:space:]]/}"         # trim whitespace
+
+        if [[ -z "$new_ver" ]]; then
+            print_error "git-cliff --bumped-version returned nothing."
+            print_error "Specify the bump explicitly: --release --minor | --major | --revision"
+            exit 1
+        fi
+        print_info "git-cliff derived next version: $new_ver"
+    fi
+
+    confirm "Release: $raw → $new_ver (will tag v$new_ver)?" \
+        || { print_warning "Cancelled."; exit 0; }
+
+    update_cargo_version "$new_ver"
+    update_changelog "v$new_ver"
+    git add Cargo.toml Cargo.lock CHANGELOG.md
+
+    print_info ""
+    print_info "Release prepared. Next steps:"
+    print_info "  1. Review staged changes : git diff --cached"
+    print_info "  2. Commit                : git commit -m 'chore(release): prepare for v$new_ver'"
+    print_info "  3. Open PR → merge to main"
+    print_info "  4. Tag on main           : git tag -a v$new_ver -m 'Release v$new_ver'"
+    print_info "  5. Push tag              : git push && git push --tags"
+    print_info "  6. After release         : ./bump-version.sh --post-release"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Argument parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
 main() {
-    # Check if no arguments provided
-    if [ $# -eq 0 ]; then
+    if [[ $# -eq 0 ]]; then
         show_help
         exit 0
     fi
 
-    # Parse arguments
-    bump_type=""
-
     case "$1" in
-        --revision)
-            bump_type="revision"
+        --post-release)
+            cmd_post_release
             ;;
-        --minor)
-            bump_type="minor"
+        --release)
+            local bump_override=""
+            if [[ $# -gt 1 ]]; then
+                case "$2" in
+                    --revision) bump_override="revision" ;;
+                    --minor)    bump_override="minor"    ;;
+                    --major)    bump_override="major"    ;;
+                    *)
+                        print_error "Unknown option for --release: $2"
+                        echo ""
+                        show_help
+                        exit 1
+                        ;;
+                esac
+            fi
+            cmd_release "$bump_override"
             ;;
-        --major)
-            bump_type="major"
-            ;;
-        --help|-h)
-            show_help
-            exit 0
-            ;;
+        --revision) cmd_dev_bump "revision" ;;
+        --minor)    cmd_dev_bump "minor"    ;;
+        --major)    cmd_dev_bump "major"    ;;
+        --help|-h)  show_help ;;
         *)
             print_error "Unknown option: $1"
             echo ""
@@ -161,44 +268,6 @@ main() {
             exit 1
             ;;
     esac
-
-    # Check dependencies
-    check_dependencies
-
-    # Get current version
-    current_version=$(get_current_version)
-    print_info "Current version: $current_version"
-
-    # Calculate new version
-    new_version=$(bump_version "$current_version" "$bump_type")
-    print_info "New version: $new_version"
-
-    # Confirm with user
-    read -p "Do you want to proceed with version bump from $current_version to $new_version? (y/N) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        print_warning "Version bump cancelled"
-        exit 0
-    fi
-
-    # Update Cargo.toml
-    update_cargo_version "$new_version"
-
-    # Update CHANGELOG.md
-    update_changelog "$new_version"
-
-    # Stage files
-    print_info "Staging updated files..."
-    git add Cargo.toml CHANGELOG.md
-
-    print_info ""
-    print_info "Version bump complete!"
-    print_info ""
-    print_info "Next steps:"
-    print_info "  1. Review the changes: git diff --cached"
-    print_info "  2. Commit the changes: git commit -m 'chore(release): prepare for v$new_version'"
-    print_info "  3. Create a git tag: git tag -a v$new_version -m 'Release v$new_version'"
-    print_info "  4. Push changes: git push && git push --tags"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Implements the `X.Y.Z-dev → X.Y.Z` release lifecycle discussed in the version management design.

### New `bump-version.sh` commands

| Command | Input | Output | Use case |
|---|---|---|---|
| `--post-release` | `0.3.0` | `0.3.0-dev` | Immediately after tagging a release |
| `--release` | `0.3.0-dev` | `0.3.1 / 0.4.0 / 1.0.0` | Auto-derives bump from conventional commits |
| `--release --minor` | `0.3.0-dev` | `0.4.0` | Override auto-derived type |
| `--minor` | `0.3.0-dev` | `0.4.0-dev` | Mid-cycle re-plan (optional) |

### Key design decisions

- **No pre-declaration of next version**: `--post-release` only adds the `-dev` suffix without bumping — `0.3.0-dev` means "unreleased work on top of 0.3.0", not "the next release will be 0.4.0".
- **Bump decided at release time**: `--release` calls `git-cliff --bumped-version` to derive the correct bump from conventional commit types (`fix:` → patch, `feat:` → minor, `feat!:` → major). Pass `--release --minor` etc. to override.
- **No CHANGELOG on dev steps**: `--post-release` and mid-cycle `--minor/--major/--revision` only touch `Cargo.toml`/`Cargo.lock`. CHANGELOG is only finalised on `--release`.

### Release workflow guard

Adds a step to the Release workflow that fails fast if:
- `Cargo.toml` version still contains a `-dev` suffix (forgot to run `--release`)
- `Cargo.toml` version does not match the pushed tag