### PR TITLE
chore: begin development on next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lorm"
-version = "0.2.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "lorm-macros"
-version = "0.2.2"
+version = "0.4.0"
 dependencies = [
  "darling",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.4.0"
+version = "0.4.0-dev"
 license = "Apache-2.0"
 license-file = "LICENSE"
 repository = "https://github.com/remysaissy/lorm.git"

--- a/lorm/Cargo.toml
+++ b/lorm/Cargo.toml
@@ -22,7 +22,7 @@ postgres = ["lorm-macros/postgres", "sqlx/postgres"]
 mysql = ["lorm-macros/mysql", "sqlx/mysql"]
 
 [dependencies]
-lorm-macros = { path = "../lorm-macros", version = "0.4.0", default-features = false }
+lorm-macros = { path = "../lorm-macros", version = "0.4.0-dev", default-features = false }
 sqlx = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror = { workspace = true, features = ["std"] }


### PR DESCRIPTION
Post-release: adds `-dev` suffix to version (`0.4.0 → 0.4.0-dev`) to signal unreleased work. No functional changes.