### PR TITLE
ci: add Trusted Publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,46 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: 'attestation-output/lorm-*.crate'
+
+  publish:
+    name: Publish to crates.io
+    needs: attest
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://crates.io/crates/lorm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: rustup toolchain install
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Authenticate with crates.io via Trusted Publishing
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      # lorm-macros must be published before lorm (dependency ordering)
+      - name: Publish lorm-macros
+        run: cargo publish -p lorm-macros --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Wait for crates.io to index lorm-macros
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "Waiting for lorm-macros $VERSION to appear on crates.io..."
+          for i in $(seq 1 30); do
+            if cargo search lorm-macros 2>/dev/null | grep -q "lorm-macros = \"$VERSION\""; then
+              echo "lorm-macros $VERSION is now indexed."
+              exit 0
+            fi
+            echo "Attempt $i/30 — not yet indexed, waiting 10s..."
+            sleep 10
+          done
+          echo "ERROR: lorm-macros $VERSION was not indexed after 5 minutes."
+          exit 1
+
+      - name: Publish lorm
+        run: cargo publish -p lorm --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,8 @@ show_help() {
 Usage: ./release.sh [OPTION]
 
 Perform a full release: bump version, update changelog, commit, tag, push,
-publish to crates.io, and create a GitHub release.
+and create a GitHub release. Publishing to crates.io is handled automatically
+by the release workflow via Trusted Publishing.
 
 Options:
     --revision    Bump the patch version    (0.0.X)
@@ -26,7 +27,6 @@ Requirements:
     - git-cliff   (cargo install git-cliff)
     - gh           (GitHub CLI, brew install gh)
     - cargo        (Rust toolchain)
-    - CARGO_REGISTRY_TOKEN env var or cargo login (for crates.io publishing)
 
 EOF
 }
@@ -110,22 +110,6 @@ run_tests() {
     cargo test --workspace
 }
 
-publish_crate() {
-    local crate_name=$1
-    local dry_run=$2
-
-    print_step "Publishing $crate_name to crates.io..."
-
-    if [ "$dry_run" = "true" ]; then
-        cargo publish --dry-run -p "$crate_name"
-    else
-        cargo publish -p "$crate_name"
-
-        print_info "Waiting for crates.io to index $crate_name..."
-        sleep 30
-    fi
-}
-
 main() {
     if [ $# -eq 0 ]; then
         show_help
@@ -177,19 +161,19 @@ main() {
 
     echo ""
 
-    print_step "1/7 Running tests..."
+    print_step "1/6 Running tests..."
     run_tests
     echo ""
 
-    print_step "2/7 Bumping version to $new_version..."
+    print_step "2/6 Bumping version to $new_version..."
     update_cargo_version "$new_version"
     print_info "Updated Cargo.toml"
 
-    print_step "3/7 Generating changelog..."
+    print_step "3/6 Generating changelog..."
     generate_changelog "$new_version"
     print_info "Updated CHANGELOG.md"
 
-    print_step "4/7 Creating release commit and tag..."
+    print_step "4/6 Creating release commit and tag..."
     git add Cargo.toml lorm/Cargo.toml CHANGELOG.md
     git commit -m "chore(release): prepare for v$new_version"
     git tag -a "v$new_version" -m "Release v$new_version"
@@ -197,31 +181,21 @@ main() {
 
     if [ "$dry_run" = "true" ]; then
         echo ""
-        print_step "5/7 [DRY RUN] Skipping push"
-        print_step "6/7 [DRY RUN] Validating crate packages..."
-        publish_crate "lorm-macros" "true"
-        publish_crate "lorm" "true"
-        print_step "7/7 [DRY RUN] Skipping GitHub release"
+        print_step "5/6 [DRY RUN] Skipping push"
+        print_step "6/6 [DRY RUN] Skipping GitHub release"
         echo ""
         print_info "Dry run complete. To finalize:"
         print_info "  git push && git push --tags"
-        print_info "  cargo publish -p lorm-macros && sleep 30 && cargo publish -p lorm"
         print_info "  gh release create v$new_version --generate-notes"
         return
     fi
 
-    print_step "5/7 Pushing to remote..."
+    print_step "5/6 Pushing to remote..."
     git push
     git push --tags
     print_info "Pushed commit and tag"
 
-    # lorm-macros must be published before lorm (dependency ordering)
-    print_step "6/7 Publishing crates..."
-    publish_crate "lorm-macros" "false"
-    publish_crate "lorm" "false"
-    print_info "Both crates published"
-
-    print_step "7/7 Creating GitHub release..."
+    print_step "6/6 Creating GitHub release..."
     gh release create "v$new_version" \
         --title "v$new_version" \
         --notes-file CHANGELOG.md
@@ -232,8 +206,8 @@ main() {
     print_info ""
     print_info "The release workflow will now run on the pushed tag to:"
     print_info "  - Verify the build"
-    print_info "  - Generate build attestations (gh attestation)"
-    print_info "  - Link the release to the provenance chain"
+    print_info "  - Generate build attestations"
+    print_info "  - Publish to crates.io via Trusted Publishing"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Add a `publish` job to the release workflow that publishes both crates to crates.io using [Trusted Publishing](https://doc.rust-lang.org/cargo/reference/registry-authentication.html) (OIDC) instead of long-lived API tokens
- Remove local `cargo publish` steps from `release.sh` — publishing is now fully automated by the GitHub Actions workflow

## How it works

The new `publish` job runs after the existing `verify` → `attest` pipeline:

1. **Authenticates** with crates.io via [`rust-lang/crates-io-auth-action@v1`](https://github.com/rust-lang/crates-io-auth-action) (OIDC token exchange — no API token needed)
2. **Publishes `lorm-macros`** first (dependency ordering)
3. **Waits for crates.io indexing** (polls up to 5 minutes)
4. **Publishes `lorm`**

The OIDC token is short-lived (30 min) and automatically revoked when the job completes.

## One-time setup required after merge

Before the first release using this workflow:

1. **crates.io** — For each crate (`lorm` and `lorm-macros`), go to Settings → Trusted Publishing → Add:
   - Repository owner: `remysaissy`
   - Repository name: `lorm`
   - Workflow filename: `release.yml`
   - Environment: `release`

2. **GitHub** — Create a `release` environment in Settings → Environments (optionally add protection rules like required reviewers or branch restrictions)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Add `publish` job with OIDC auth, dependency-ordered crate publishing, and crates.io index polling |
| `release.sh` | Remove `publish_crate` function and local publish steps; update help text and step numbering |