### PR TITLE
fix(release): strip pre-release suffix before version parsing

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -78,7 +78,9 @@ calculate_new_version() {
     local bump_type=$2
     local major minor patch
 
-    read -r major minor patch <<< "$(parse_version "$current_version")"
+    # Strip any pre-release suffix (e.g. "-dev") before parsing
+    local base_version="${current_version%%-*}"
+    read -r major minor patch <<< "$(parse_version "$base_version")"
 
     case $bump_type in
         major)   major=$((major + 1)); minor=0; patch=0 ;;


### PR DESCRIPTION
## Summary

- Fix `release.sh` crash (`unbound variable`) when current version contains a pre-release suffix (e.g. `0.4.0-dev`)
- The `-dev` suffix was passed into bash arithmetic expansion, causing `dev` to be treated as an undefined variable under `set -u`
- Strip the suffix via parameter expansion (`${version%%-*}`) before splitting into major/minor/patch