### PR TITLE
feat(ci): release via PR workflow with auto-tagging on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.4.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: rustup toolchain install
       - run: rustup component add rustfmt clippy
@@ -36,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: rustup toolchain install
       - uses: Swatinem/rust-cache@v2
@@ -43,7 +53,9 @@ jobs:
       - name: Verify release version has no pre-release suffix
         run: |
           VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          TAG="${GITHUB_REF#refs/tags/v}"
+          RAW_TAG="${{ inputs.tag || github.ref }}"
+          TAG="${RAW_TAG#refs/tags/v}"
+          TAG="${TAG#v}"
           if [[ "$VERSION" == *-* ]]; then
             echo "ERROR: Cargo.toml version '$VERSION' contains a pre-release suffix."
             echo "Run './bump-version.sh --release' to strip it before tagging."
@@ -93,6 +105,8 @@ jobs:
       url: https://crates.io/crates/lorm
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: rustup toolchain install
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,66 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  tag-and-release:
+    # Only run when a release PR is merged (not just closed)
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract version from PR title
+        id: version
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          if [[ ! "$TITLE" =~ ^Release\ v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "ERROR: PR title '$TITLE' does not match 'Release vX.Y.Z' format."
+            exit 1
+          fi
+          VERSION="${BASH_REMATCH[1]}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected release version: v$VERSION"
+
+      - name: Verify version matches Cargo.toml
+        run: |
+          CARGO_VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          if [ "$CARGO_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "ERROR: Cargo.toml version '$CARGO_VERSION' does not match PR version '${{ steps.version.outputs.version }}'."
+            exit 1
+          fi
+
+      - name: Check tag does not already exist
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "ERROR: Tag v${{ steps.version.outputs.version }} already exists."
+            exit 1
+          fi
+
+      - name: Create GitHub release with tag
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --target main \
+            --title "v${{ steps.version.outputs.version }}" \
+            --notes-file CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger release workflow
+        run: |
+          gh workflow run release.yml \
+            -f tag="v${{ steps.version.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release.sh
+++ b/release.sh
@@ -12,15 +12,16 @@ show_help() {
     cat << 'EOF'
 Usage: ./release.sh [OPTION]
 
-Perform a full release: bump version, update changelog, commit, tag, push,
-and create a GitHub release. Publishing to crates.io is handled automatically
-by the release workflow via Trusted Publishing.
+Perform a full release: bump version, update changelog, commit, and open a
+pull request. Once the PR is merged, the tag-release workflow automatically
+creates the git tag and GitHub release. Publishing to crates.io is then
+handled by the release workflow via Trusted Publishing.
 
 Options:
     --revision    Bump the patch version    (0.0.X)
     --minor       Bump the minor version    (0.X.0)
     --major       Bump the major version    (X.0.0)
-    --dry-run     Run all steps except push, publish, and GitHub release
+    --dry-run     Run all steps except push and PR creation
     --help        Display this help message
 
 Requirements:
@@ -150,7 +151,7 @@ main() {
     print_info "Current version: $current_version"
     print_info "New version:     $new_version"
     if [ "$dry_run" = "true" ]; then
-        print_warning "DRY RUN — no push, publish, or GitHub release will be performed"
+        print_warning "DRY RUN — no push or PR creation will be performed"
     fi
     echo ""
 
@@ -175,41 +176,51 @@ main() {
     generate_changelog "$new_version"
     print_info "Updated CHANGELOG.md"
 
-    print_step "4/6 Creating release commit and tag..."
+    local release_branch="release/v$new_version"
+
+    print_step "4/6 Creating release branch and commit..."
+    git checkout -b "$release_branch"
     git add Cargo.toml lorm/Cargo.toml CHANGELOG.md
     git commit -m "chore(release): prepare for v$new_version"
-    git tag -a "v$new_version" -m "Release v$new_version"
-    print_info "Created commit and tag v$new_version"
+    print_info "Created commit on branch $release_branch"
 
     if [ "$dry_run" = "true" ]; then
         echo ""
         print_step "5/6 [DRY RUN] Skipping push"
-        print_step "6/6 [DRY RUN] Skipping GitHub release"
+        print_step "6/6 [DRY RUN] Skipping PR creation"
         echo ""
         print_info "Dry run complete. To finalize:"
-        print_info "  git push && git push --tags"
-        print_info "  gh release create v$new_version --generate-notes"
+        print_info "  git push -u origin $release_branch"
+        print_info "  gh pr create --base main --head $release_branch --title 'Release v$new_version' --label release"
         return
     fi
 
-    print_step "5/6 Pushing to remote..."
-    git push
-    git push --tags
-    print_info "Pushed commit and tag"
+    print_step "5/6 Pushing release branch..."
+    git push -u origin "$release_branch"
+    print_info "Pushed branch $release_branch"
 
-    print_step "6/6 Creating GitHub release..."
-    gh release create "v$new_version" \
-        --title "v$new_version" \
-        --notes-file CHANGELOG.md
-    print_info "GitHub release created"
+    print_step "6/6 Opening pull request..."
+    gh pr create \
+        --base main \
+        --head "$release_branch" \
+        --title "Release v$new_version" \
+        --label "release" \
+        --body "$(cat CHANGELOG.md)"
+    print_info "Pull request created"
 
     echo ""
-    print_info "Release v$new_version complete!"
+    print_info "Release v$new_version prepared!"
     print_info ""
-    print_info "The release workflow will now run on the pushed tag to:"
-    print_info "  - Verify the build"
-    print_info "  - Generate build attestations"
-    print_info "  - Publish to crates.io via Trusted Publishing"
+    print_info "Next steps:"
+    print_info "  1. Wait for CI checks to pass on the PR"
+    print_info "  2. Squash-merge the PR into main"
+    print_info "  3. The tag-release workflow will automatically:"
+    print_info "     - Create the v$new_version tag"
+    print_info "     - Create the GitHub release with changelog"
+    print_info "  4. The release workflow will then:"
+    print_info "     - Verify the build"
+    print_info "     - Generate build attestations"
+    print_info "     - Publish to crates.io via Trusted Publishing"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Adapts the release process to work with branch protection on `main`. Instead of pushing directly to main + creating tags, releases now go through PRs.

### Changes

- **`release.sh`**: Creates a `release/vX.Y.Z` branch, commits the version bump + changelog, and opens a PR with the `release` label instead of pushing directly to main
- **`tag-release.yml`** (new): Triggers on merged PRs with the `release` label — extracts the version from the PR title, creates a GitHub release (which creates the tag), then triggers the release workflow via `workflow_dispatch`
- **`release.yml`**: Adds `workflow_dispatch` trigger with a `tag` input so it can be invoked by `tag-release.yml`. All checkout steps now use `ref: ${{ inputs.tag || github.ref }}` to work with both trigger types

### New release flow

1. Run `./release.sh --revision` (or `--minor`/`--major`) locally
2. Script creates `release/vX.Y.Z` branch → bumps version → generates changelog → opens PR
3. CI runs on the PR, reviewer squash-merges
4. `tag-release.yml` fires → creates GitHub release + tag → triggers `release.yml`
5. `release.yml` runs → verify → attest → publish to crates.io via Trusted Publishing

### Why `workflow_dispatch` instead of relying on tag push events

Tags created by `gh release create` with `GITHUB_TOKEN` do **not** trigger `on: push: tags` workflows (GitHub prevents `GITHUB_TOKEN`-triggered events from creating new workflow runs). The `workflow_dispatch` trigger is the cleanest workaround that requires no PATs or GitHub Apps.