### PR TITLE
fix(ci): allow dirty working directory during crate packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,15 +71,14 @@ jobs:
 
       - name: Package crates for attestation
         run: |
-          # lorm-macros has no unpublished path deps — package normally
-          cargo package -p lorm-macros --target-dir attestation-artifacts
+          cargo package -p lorm-macros --allow-dirty --target-dir attestation-artifacts
 
           # lorm depends on lorm-macros which is not yet on crates.io.
           # Patch crates-io to use the local workspace copy so cargo can resolve
           # the dependency when generating the packaged manifest, then package
           # without re-verifying the build (already done in the prior step).
           printf '\n[patch.crates-io]\nlorm-macros = { path = "lorm-macros" }\n' >> Cargo.toml
-          cargo package -p lorm --no-verify --target-dir attestation-artifacts
+          cargo package -p lorm --allow-dirty --no-verify --target-dir attestation-artifacts
           git checkout Cargo.toml
 
           mkdir -p attestation-output


### PR DESCRIPTION
## Summary

The `cargo build --release` step in the attestation job updates `Cargo.lock`, making the working tree dirty. The subsequent `cargo package` calls then fail with "1 files in the working directory contain changes that were not yet committed into git".

Adds `--allow-dirty` to both `cargo package` calls in the attestation job. This is safe — the attestation job only packages crates for provenance signing, not for publishing (the publish job uses `cargo publish` directly).