### PR TITLE
fix(ci): correct crate path and add automated post-release version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Package and attest lorm-macros
         run: |
           cargo package -p lorm-macros --allow-dirty --target-dir attestation-artifacts
-          cp attestation-artifacts/package/lorm-macros-*/lorm-macros-*.crate .
+          cp attestation-artifacts/package/lorm-macros-*.crate .
 
       - name: Attest lorm-macros crate
         uses: actions/attest-build-provenance@v2
@@ -109,7 +109,7 @@ jobs:
       - name: Package and attest lorm
         run: |
           cargo package -p lorm --allow-dirty --no-verify --target-dir attestation-artifacts
-          cp attestation-artifacts/package/lorm-*/lorm-*.crate .
+          cp attestation-artifacts/package/lorm-*.crate .
 
       - name: Attest lorm crate
         uses: actions/attest-build-provenance@v2

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   tag-and-release:
@@ -62,5 +63,35 @@ jobs:
         run: |
           gh workflow run release.yml \
             -f tag="v${{ steps.version.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute next dev version
+        id: next
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          NEXT_DEV="$major.$minor.$((patch + 1))-dev"
+          echo "version=$NEXT_DEV" >> "$GITHUB_OUTPUT"
+          echo "Next dev version: $NEXT_DEV"
+
+      - name: Create post-release branch
+        run: |
+          BRANCH="chore/post-release-v${{ steps.version.outputs.version }}"
+          git checkout -b "$BRANCH"
+
+          sed -i "s/^version = \".*\"/version = \"${{ steps.next.outputs.version }}\"/" Cargo.toml
+          sed -i "/^lorm-macros = /s/version = \"[^\"]*\"/version = \"${{ steps.next.outputs.version }}\"/" lorm/Cargo.toml
+
+          git add Cargo.toml lorm/Cargo.toml
+          git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "chore: begin development on ${{ steps.next.outputs.version }}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: begin development on ${{ steps.next.outputs.version }}" \
+            --body "Automated post-release version bump after v${{ steps.version.outputs.version }}."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Two fixes for the release workflow:

1. **Fix crate file path in attestation step** — `cargo package` outputs `.crate` files at `package/lorm-macros-0.4.3.crate`, not inside a subdirectory. Fixes the `cp` glob that was causing "No such file or directory" errors.

2. **Automated post-release version bump** — After `tag-release.yml` creates the tag and triggers the release workflow, it now also creates a PR to bump `main` to the next dev version (e.g. `0.4.3` → `0.4.4-dev`). Always bumps revision.