### PR TITLE
fix(ci): remove redundant cargo search polling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,21 +91,6 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-      - name: Wait for crates.io to index lorm-macros
-        run: |
-          VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "Waiting for lorm-macros $VERSION to appear on crates.io..."
-          for i in $(seq 1 30); do
-            if cargo search lorm-macros 2>/dev/null | grep -q "lorm-macros = \"$VERSION\""; then
-              echo "lorm-macros $VERSION is now indexed."
-              exit 0
-            fi
-            echo "Attempt $i/30 — not yet indexed, waiting 10s..."
-            sleep 10
-          done
-          echo "ERROR: lorm-macros $VERSION was not indexed after 5 minutes."
-          exit 1
-
       - name: Package and attest lorm
         run: |
           cargo package -p lorm --allow-dirty --no-verify --target-dir attestation-artifacts


### PR DESCRIPTION
## Summary

Remove the \`cargo search\` polling loop that waits for lorm-macros to be indexed on crates.io after publish.

\`cargo publish\` already waits for indexing internally before returning (prints "Published lorm-macros vX.Y.Z at registry crates-io"). The separate \`cargo search\` loop uses a different cache/index and has timed out twice despite the crate being available, causing release failures.

Fixes https://github.com/lorm-rs/lorm/actions/runs/25775625574 and https://github.com/lorm-rs/lorm/actions/runs/25776632319.