### PR TITLE
test(lorm-macros): improve test coverage - predicates, utils, save, compile_fail snapshot

### DIFF
--- a/lorm-macros/src/orm/save.rs
+++ b/lorm-macros/src/orm/save.rs
@@ -418,3 +418,83 @@ pub(crate) fn create_update_placeholders<'a>(fields: &[&Column<'a>]) -> String {
         .collect::<Vec<_>>()
         .join(",")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_str;
+
+    fn create_test_column(name: &str, ty: &str) -> Column<'static> {
+        let item_str = format!("struct TestStruct {{ pub {}: {} }}", name, ty);
+        let item: syn::ItemStruct = parse_str(&item_str).unwrap();
+        let field = item.fields.iter().next().unwrap().clone();
+        
+        let boxed = Box::new(field);
+        let field_ref = Box::leak(boxed);
+        
+        Column {
+            base_field: field_ref,
+            column_name: name.to_string(),
+            field: parse_str::<syn::Ident>(name).unwrap(),
+            ty: parse_str(ty).unwrap(),
+            is_flattened: false,
+            column_properties: crate::attributes::ColumnProperties {
+                skip: false,
+                readonly: false,
+                primary_key: false,
+                generate_by: false,
+                created_at: false,
+                updated_at: false,
+                new_expression: parse_str("Default::default()").unwrap(),
+                is_set_expression: None,
+                use_json: false,
+                belongs_to_target: None,
+            },
+            belongs_to: None,
+        }
+    }
+
+    #[test]
+    fn test_create_insert_placeholders_empty() {
+        let columns: Vec<&Column> = vec![];
+        assert_eq!(create_insert_placeholders(&columns), "");
+    }
+
+    #[test]
+    fn test_create_insert_placeholders_single() {
+        let col = create_test_column("id", "i32");
+        let columns = vec![&col];
+        assert_eq!(create_insert_placeholders(&columns), "$1");
+    }
+
+    #[test]
+    fn test_create_insert_placeholders_multiple() {
+        let col1 = create_test_column("id", "i32");
+        let col2 = create_test_column("name", "String");
+        let col3 = create_test_column("email", "String");
+        let columns = vec![&col1, &col2, &col3];
+        assert_eq!(create_insert_placeholders(&columns), "$1,$2,$3");
+    }
+
+    #[test]
+    fn test_create_update_placeholders_empty() {
+        let columns: Vec<&Column> = vec![];
+        assert_eq!(create_update_placeholders(&columns), "");
+    }
+
+    #[test]
+    fn test_create_update_placeholders_single() {
+        let col = create_test_column("name", "String");
+        let columns = vec![&col];
+        assert_eq!(create_update_placeholders(&columns), "name = $1");
+    }
+
+    #[test]
+    fn test_create_update_placeholders_multiple() {
+        let col1 = create_test_column("name", "String");
+        let col2 = create_test_column("email", "String");
+        let col3 = create_test_column("age", "i32");
+        let columns = vec![&col1, &col2, &col3];
+        assert_eq!(create_update_placeholders(&columns), "name = $1,email = $2,age = $3");
+    }
+}

--- a/lorm-macros/src/utils.rs
+++ b/lorm-macros/src/utils.rs
@@ -280,4 +280,57 @@ mod tests {
         let p: syn::Path = syn::parse_str("User").unwrap();
         assert_eq!(default_belongs_to_method(&p), "user");
     }
+
+    #[test]
+    fn is_primitive_type_detects_primitives() {
+        for prim in &["i8", "i16", "i32", "i64", "i128", "isize",
+                      "u8", "u16", "u32", "u64", "u128", "usize",
+                      "f32", "f64", "bool", "char"] {
+            let ty: Type = syn::parse_str(prim).unwrap();
+            assert!(is_primitive_type(&ty), "{prim} should be primitive");
+        }
+    }
+
+    #[test]
+    fn is_primitive_type_rejects_non_primitives() {
+        for non_prim in &["String", "Uuid", "Vec<u8>", "Option<i32>"] {
+            let ty: Type = syn::parse_str(non_prim).unwrap();
+            assert!(!is_primitive_type(&ty), "{non_prim} should NOT be primitive");
+        }
+    }
+
+    #[test]
+    fn is_option_wrapped_detects_option() {
+        let ty: Type = syn::parse_str("Option<i32>").unwrap();
+        assert!(is_option_wrapped(&ty));
+
+        let ty: Type = syn::parse_str("Option<String>").unwrap();
+        assert!(is_option_wrapped(&ty));
+
+        let ty: Type = syn::parse_str("Option<Uuid>").unwrap();
+        assert!(is_option_wrapped(&ty));
+    }
+
+    #[test]
+    fn is_option_wrapped_rejects_bare_types() {
+        for bare in &["i32", "String", "Uuid", "Vec<u8>"] {
+            let ty: Type = syn::parse_str(bare).unwrap();
+            assert!(!is_option_wrapped(&ty), "{bare} should NOT be Option-wrapped");
+        }
+    }
+
+    #[test]
+    fn db_placeholder_sqlite_feature() {
+        let input: syn::DeriveInput = syn::parse_str("struct S { id: i32 }").unwrap();
+        let field = match &input.data {
+            syn::Data::Struct(s) => s.fields.iter().next().unwrap(),
+            _ => panic!("expected struct"),
+        };
+        let result = db_placeholder(field, 1).unwrap();
+        // With sqlite feature active, should return $1
+        assert_eq!(result, "$1");
+
+        let result3 = db_placeholder(field, 3).unwrap();
+        assert_eq!(result3, "$3");
+    }
 }

--- a/lorm-macros/tests/compile_fail/has_many_no_as_for_self.stderr
+++ b/lorm-macros/tests/compile_fail/has_many_no_as_for_self.stderr
@@ -4,5 +4,5 @@ error[E0283]: type annotations needed
 5 | #[derive(Debug, Default, Clone, FromRow, ToLOrm)]
   |                                          ^^^^^^ cannot infer type
   |
-  = note: the type must implement `Default`
+  = note: cannot satisfy `_: Default`
   = note: this error originates in the derive macro `ToLOrm` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/lorm/src/predicates.rs
+++ b/lorm/src/predicates.rs
@@ -48,6 +48,7 @@ pub enum Where {
 }
 
 impl Display for Where {
+    #[allow(unused_variables)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Where::Eq => write!(f, "="),
@@ -103,6 +104,7 @@ pub enum Having {
 }
 
 impl Display for Having {
+    #[allow(unused_variables)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Having::Eq => write!(f, "="),
@@ -140,6 +142,7 @@ pub enum Function {
 }
 
 impl Display for Function {
+    #[allow(unused_variables)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Function::Null => write!(f, ""),
@@ -149,5 +152,43 @@ impl Display for Function {
             Function::Min => write!(f, "MIN"),
             Function::Max => write!(f, "MAX"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_where_display() {
+        assert_eq!(Where::Eq.to_string(), "=");
+        assert_eq!(Where::NotEq.to_string(), "!=");
+        assert_eq!(Where::GreaterThan.to_string(), ">");
+        assert_eq!(Where::GreaterOrEqualTo.to_string(), ">=");
+        assert_eq!(Where::LesserThan.to_string(), "<");
+        assert_eq!(Where::LesserOrEqualTo.to_string(), "<=");
+        assert_eq!(Where::Like.to_string(), "LIKE");
+    }
+
+    #[test]
+    fn test_having_display() {
+        assert_eq!(Having::Eq.to_string(), "=");
+        assert_eq!(Having::NotEq.to_string(), "!=");
+        assert_eq!(Having::GreaterThan.to_string(), ">");
+        assert_eq!(Having::GreaterOrEqualTo.to_string(), ">=");
+        assert_eq!(Having::LesserThan.to_string(), "<");
+        assert_eq!(Having::LesserOrEqualTo.to_string(), "<=");
+        assert_eq!(Having::Like.to_string(), "LIKE");
+    }
+
+    #[test]
+    fn test_function_display() {
+        assert_eq!(Function::Null.to_string(), "");
+        assert_eq!(Function::Count { is_distinct: false }.to_string(), "COUNT");
+        assert_eq!(Function::Count { is_distinct: true }.to_string(), "COUNT");
+        assert_eq!(Function::Sum.to_string(), "SUM");
+        assert_eq!(Function::Avg.to_string(), "AVG");
+        assert_eq!(Function::Min.to_string(), "MIN");
+        assert_eq!(Function::Max.to_string(), "MAX");
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses gaps identified by `cargo-mutants` across both `lorm` and `lorm-macros` crates, and fixes a stale compile_fail snapshot.

### Changes

**`lorm/src/predicates.rs`**
- Add `#[allow(unused_variables)]` to suppress Rust 2024 edition false-positive warning on `fmt` methods
- Add `#[cfg(test)]` unit tests covering all variants of `Where`, `Having`, and `Function` `Display` impls — previously 0% mutation-test coverage

**`lorm-macros/src/utils.rs`**
- Add unit tests for `is_primitive_type` (primitive vs non-primitive detection), `is_option_wrapped` (Option type detection), and `db_placeholder` (SQLite `$N` placeholder format) — previously untested by cargo-mutants

**`lorm-macros/src/orm/save.rs`**
- Add unit tests for `create_insert_placeholders` and `create_update_placeholders` — pure functions previously missed entirely by mutation testing

**`lorm-macros/tests/compile_fail/has_many_no_as_for_self.stderr`**
- Update stale trybuild snapshot to match current Rust compiler output (`cannot satisfy '_: Default'` instead of `the type must implement 'Default'`)

### Test results

```
test result: ok. 3 passed  (lorm lib)
test result: ok. 36 passed (lorm integration)
test result: ok. 15 passed (lorm-macros lib — was 4 before this PR)
test result: ok. 1 passed  (lorm-macros compile_fail — was failing before)
```