### PR TITLE
test(lorm-macros): add unit tests for save placeholders and utility functions

### DIFF
--- a/lorm-macros/src/orm/save.rs
+++ b/lorm-macros/src/orm/save.rs
@@ -428,10 +428,10 @@ mod tests {
         let item_str = format!("struct TestStruct {{ pub {}: {} }}", name, ty);
         let item: syn::ItemStruct = parse_str(&item_str).unwrap();
         let field = item.fields.iter().next().unwrap().clone();
-        
+
         let boxed = Box::new(field);
         let field_ref = Box::leak(boxed);
-        
+
         Column {
             base_field: field_ref,
             column_name: name.to_string(),
@@ -495,6 +495,9 @@ mod tests {
         let col2 = create_test_column("email", "String");
         let col3 = create_test_column("age", "i32");
         let columns = vec![&col1, &col2, &col3];
-        assert_eq!(create_update_placeholders(&columns), "name = $1,email = $2,age = $3");
+        assert_eq!(
+            create_update_placeholders(&columns),
+            "name = $1,email = $2,age = $3"
+        );
     }
 }

--- a/lorm-macros/src/orm/save.rs
+++ b/lorm-macros/src/orm/save.rs
@@ -418,3 +418,83 @@ pub(crate) fn create_update_placeholders<'a>(fields: &[&Column<'a>]) -> String {
         .collect::<Vec<_>>()
         .join(",")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_str;
+
+    fn create_test_column(name: &str, ty: &str) -> Column<'static> {
+        let item_str = format!("struct TestStruct {{ pub {}: {} }}", name, ty);
+        let item: syn::ItemStruct = parse_str(&item_str).unwrap();
+        let field = item.fields.iter().next().unwrap().clone();
+        
+        let boxed = Box::new(field);
+        let field_ref = Box::leak(boxed);
+        
+        Column {
+            base_field: field_ref,
+            column_name: name.to_string(),
+            field: parse_str::<syn::Ident>(name).unwrap(),
+            ty: parse_str(ty).unwrap(),
+            is_flattened: false,
+            column_properties: crate::attributes::ColumnProperties {
+                skip: false,
+                readonly: false,
+                primary_key: false,
+                generate_by: false,
+                created_at: false,
+                updated_at: false,
+                new_expression: parse_str("Default::default()").unwrap(),
+                is_set_expression: None,
+                use_json: false,
+                belongs_to_target: None,
+            },
+            belongs_to: None,
+        }
+    }
+
+    #[test]
+    fn test_create_insert_placeholders_empty() {
+        let columns: Vec<&Column> = vec![];
+        assert_eq!(create_insert_placeholders(&columns), "");
+    }
+
+    #[test]
+    fn test_create_insert_placeholders_single() {
+        let col = create_test_column("id", "i32");
+        let columns = vec![&col];
+        assert_eq!(create_insert_placeholders(&columns), "$1");
+    }
+
+    #[test]
+    fn test_create_insert_placeholders_multiple() {
+        let col1 = create_test_column("id", "i32");
+        let col2 = create_test_column("name", "String");
+        let col3 = create_test_column("email", "String");
+        let columns = vec![&col1, &col2, &col3];
+        assert_eq!(create_insert_placeholders(&columns), "$1,$2,$3");
+    }
+
+    #[test]
+    fn test_create_update_placeholders_empty() {
+        let columns: Vec<&Column> = vec![];
+        assert_eq!(create_update_placeholders(&columns), "");
+    }
+
+    #[test]
+    fn test_create_update_placeholders_single() {
+        let col = create_test_column("name", "String");
+        let columns = vec![&col];
+        assert_eq!(create_update_placeholders(&columns), "name = $1");
+    }
+
+    #[test]
+    fn test_create_update_placeholders_multiple() {
+        let col1 = create_test_column("name", "String");
+        let col2 = create_test_column("email", "String");
+        let col3 = create_test_column("age", "i32");
+        let columns = vec![&col1, &col2, &col3];
+        assert_eq!(create_update_placeholders(&columns), "name = $1,email = $2,age = $3");
+    }
+}

--- a/lorm-macros/src/utils.rs
+++ b/lorm-macros/src/utils.rs
@@ -280,4 +280,57 @@ mod tests {
         let p: syn::Path = syn::parse_str("User").unwrap();
         assert_eq!(default_belongs_to_method(&p), "user");
     }
+
+    #[test]
+    fn is_primitive_type_detects_primitives() {
+        for prim in &["i8", "i16", "i32", "i64", "i128", "isize",
+                      "u8", "u16", "u32", "u64", "u128", "usize",
+                      "f32", "f64", "bool", "char"] {
+            let ty: Type = syn::parse_str(prim).unwrap();
+            assert!(is_primitive_type(&ty), "{prim} should be primitive");
+        }
+    }
+
+    #[test]
+    fn is_primitive_type_rejects_non_primitives() {
+        for non_prim in &["String", "Uuid", "Vec<u8>", "Option<i32>"] {
+            let ty: Type = syn::parse_str(non_prim).unwrap();
+            assert!(!is_primitive_type(&ty), "{non_prim} should NOT be primitive");
+        }
+    }
+
+    #[test]
+    fn is_option_wrapped_detects_option() {
+        let ty: Type = syn::parse_str("Option<i32>").unwrap();
+        assert!(is_option_wrapped(&ty));
+
+        let ty: Type = syn::parse_str("Option<String>").unwrap();
+        assert!(is_option_wrapped(&ty));
+
+        let ty: Type = syn::parse_str("Option<Uuid>").unwrap();
+        assert!(is_option_wrapped(&ty));
+    }
+
+    #[test]
+    fn is_option_wrapped_rejects_bare_types() {
+        for bare in &["i32", "String", "Uuid", "Vec<u8>"] {
+            let ty: Type = syn::parse_str(bare).unwrap();
+            assert!(!is_option_wrapped(&ty), "{bare} should NOT be Option-wrapped");
+        }
+    }
+
+    #[test]
+    fn db_placeholder_sqlite_feature() {
+        let input: syn::DeriveInput = syn::parse_str("struct S { id: i32 }").unwrap();
+        let field = match &input.data {
+            syn::Data::Struct(s) => s.fields.iter().next().unwrap(),
+            _ => panic!("expected struct"),
+        };
+        let result = db_placeholder(field, 1).unwrap();
+        // With sqlite feature active, should return $1
+        assert_eq!(result, "$1");
+
+        let result3 = db_placeholder(field, 3).unwrap();
+        assert_eq!(result3, "$3");
+    }
 }

--- a/lorm-macros/src/utils.rs
+++ b/lorm-macros/src/utils.rs
@@ -283,9 +283,10 @@ mod tests {
 
     #[test]
     fn is_primitive_type_detects_primitives() {
-        for prim in &["i8", "i16", "i32", "i64", "i128", "isize",
-                      "u8", "u16", "u32", "u64", "u128", "usize",
-                      "f32", "f64", "bool", "char"] {
+        for prim in &[
+            "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16", "u32", "u64", "u128", "usize",
+            "f32", "f64", "bool", "char",
+        ] {
             let ty: Type = syn::parse_str(prim).unwrap();
             assert!(is_primitive_type(&ty), "{prim} should be primitive");
         }
@@ -295,7 +296,10 @@ mod tests {
     fn is_primitive_type_rejects_non_primitives() {
         for non_prim in &["String", "Uuid", "Vec<u8>", "Option<i32>"] {
             let ty: Type = syn::parse_str(non_prim).unwrap();
-            assert!(!is_primitive_type(&ty), "{non_prim} should NOT be primitive");
+            assert!(
+                !is_primitive_type(&ty),
+                "{non_prim} should NOT be primitive"
+            );
         }
     }
 
@@ -315,7 +319,10 @@ mod tests {
     fn is_option_wrapped_rejects_bare_types() {
         for bare in &["i32", "String", "Uuid", "Vec<u8>"] {
             let ty: Type = syn::parse_str(bare).unwrap();
-            assert!(!is_option_wrapped(&ty), "{bare} should NOT be Option-wrapped");
+            assert!(
+                !is_option_wrapped(&ty),
+                "{bare} should NOT be Option-wrapped"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Adds unit tests for two groups of previously untested pure functions in `lorm-macros`, identified via `cargo-mutants`.

**`orm/save.rs`** — `create_insert_placeholders` and `create_update_placeholders`
- Tests for 0, 1, and 3 column cases
- Verifies `$N` placeholder format under the sqlite feature

**`utils.rs`** — `is_primitive_type`, `is_option_wrapped`, `db_placeholder`
- `is_primitive_type`: all 16 primitive types return `true`; `String`, `Uuid`, `Option<i32>` return `false`
- `is_option_wrapped`: `Option<T>` variants return `true`; bare types return `false`
- `db_placeholder`: returns `$1` / `$3` under sqlite feature

## Test results

```
test result: ok. 15 passed; 0 failed (lorm-macros --lib, was 4 before this PR)
```