### PR TITLE
chore(tests): update stale compile_fail snapshot for has_many_no_as_for_self

### DIFF
--- a/lorm-macros/tests/compile_fail/has_many_no_as_for_self.stderr
+++ b/lorm-macros/tests/compile_fail/has_many_no_as_for_self.stderr
@@ -4,5 +4,5 @@ error[E0283]: type annotations needed
 5 | #[derive(Debug, Default, Clone, FromRow, ToLOrm)]
   |                                          ^^^^^^ cannot infer type
   |
-  = note: the type must implement `Default`
+  = note: cannot satisfy `_: Default`
   = note: this error originates in the derive macro `ToLOrm` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary

The trybuild snapshot for `has_many_no_as_for_self.rs` was stale: the expected stderr contained `the type must implement 'Default'` but the current Rust compiler emits `cannot satisfy '_: Default'`.

Updated the snapshot to match current compiler output so `cargo test -p lorm-macros --test compile_fail` passes again.

## Test results

```
test result: ok. 1 passed; 0 failed (lorm-macros --test compile_fail, was failing before)
```